### PR TITLE
Generate index names dynamically

### DIFF
--- a/Migration/AbstractMigration.php
+++ b/Migration/AbstractMigration.php
@@ -73,6 +73,99 @@ abstract class AbstractMigration implements MigrationInterface
     }
 
     /**
+     * Generate the ALTER TABLE query that adds the foreign key.
+     *
+     * @param string   $table
+     * @param string[] $columns
+     * @param string   $referenceTable
+     * @param string[] $referenceColumns
+     * @param string   $suffix           usually a 'ON DELETE ...' statement
+     *
+     * @return string
+     */
+    protected function generateAlterTableForeignKeyStatement(
+        string $table,
+        array $columns,
+        string $referenceTable,
+        array $referenceColumns,
+        string $suffix = ''
+    ): string {
+        return "ALTER TABLE {$this->concatPrefix($table)} 
+            ADD CONSTRAINT {$this->generatePropertyName($table, 'fk', $columns)} 
+            FOREIGN KEY ({$this->columnsToString($columns)}) 
+            REFERENCES {$this->concatPrefix($referenceTable)} ({$this->columnsToString($referenceColumns)}) {$suffix}
+        ";
+    }
+
+    /**
+     * @param string   $table
+     * @param string[] $columns
+     *
+     * @return string
+     */
+    protected function generateIndexStatement(string $table, array $columns): string
+    {
+        return "INDEX {$this->generatePropertyName($table, 'idx', $columns)} ({$this->columnsToString($columns)})";
+    }
+
+    /**
+     * @param string[] $columns
+     *
+     * @return string
+     */
+    protected function columnsToString(array $columns): string
+    {
+        return implode(',', $columns);
+    }
+
+    /**
+     * Generate the name for the property.
+     *
+     * This method was copied from AbstractMauticMigration.
+     *
+     * @param string   $table
+     * @param string   $type
+     * @param string[] $columnNames
+     *
+     * @return string
+     */
+    protected function generatePropertyName(string $table, string $type, array $columnNames): string
+    {
+        $columnNames = array_merge([$this->tablePrefix.$table], $columnNames);
+        $hash        = implode(
+            '',
+            array_map(
+                function ($column) {
+                    return dechex(crc32($column));
+                },
+                $columnNames
+            )
+        );
+
+        return substr(strtoupper($type.'_'.$hash), 0, 63);
+    }
+
+    /**
+     * @param string $sql
+     */
+    protected function addSql(string $sql): void
+    {
+        $this->queries[] = $sql;
+    }
+
+    /**
+     * Concatenates table/index prefix to the provided name.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function concatPrefix(string $name): string
+    {
+        return $this->tablePrefix.$name;
+    }
+
+    /**
      * Define in the child migration whether the migration should be executed.
      * Check if the migration is applied in the schema already.
      *
@@ -86,12 +179,4 @@ abstract class AbstractMigration implements MigrationInterface
      * Define queries for migration up.
      */
     abstract protected function up(): void;
-
-    /**
-     * @param string $sql
-     */
-    protected function addSql(string $sql): void
-    {
-        $this->queries[] = $sql;
-    }
 }

--- a/Migrations/Version_0_0_1.php
+++ b/Migrations/Version_0_0_1.php
@@ -20,12 +20,17 @@ use Doctrine\DBAL\Schema\SchemaException;
 class Version_0_0_1 extends AbstractMigration
 {
     /**
+     * @var string
+     */
+    private $table = 'custom_object';
+
+    /**
      * {@inheritdoc}
      */
     protected function isApplicable(Schema $schema): bool
     {
         try {
-            return !$schema->getTable("{$this->tablePrefix}custom_object")->hasColumn('description');
+            return !$schema->getTable($this->concatPrefix($this->table))->hasColumn('description');
         } catch (SchemaException $e) {
             return false;
         }
@@ -37,7 +42,7 @@ class Version_0_0_1 extends AbstractMigration
     protected function up(): void
     {
         $this->addSql("
-            ALTER TABLE `{$this->tablePrefix}custom_object`
+            ALTER TABLE `{$this->concatPrefix($this->table)}`
             ADD `description` varchar(255) NULL AFTER `name_singular`
         ");
     }

--- a/Migrations/Version_0_0_2.php
+++ b/Migrations/Version_0_0_2.php
@@ -19,11 +19,16 @@ use Doctrine\DBAL\Schema\Schema;
 class Version_0_0_2 extends AbstractMigration
 {
     /**
+     * @var string
+     */
+    private $table = 'custom_item_xref_custom_item';
+
+    /**
      * {@inheritdoc}
      */
     protected function isApplicable(Schema $schema): bool
     {
-        return !$schema->hasTable("{$this->tablePrefix}custom_item_xref_custom_item");
+        return !$schema->hasTable($this->concatPrefix($this->table));
     }
 
     /**
@@ -31,26 +36,30 @@ class Version_0_0_2 extends AbstractMigration
      */
     protected function up(): void
     {
-        $this->addSql("CREATE TABLE {$this->tablePrefix}custom_item_xref_custom_item (
+        $this->addSql("CREATE TABLE {$this->concatPrefix($this->table)} (
                 custom_item_id BIGINT UNSIGNED NOT NULL, 
                 parent_custom_item_id BIGINT UNSIGNED NOT NULL, 
                 date_added DATETIME NOT NULL COMMENT '(DC2Type:datetime)', 
-                INDEX IDX_77DE7EF715363B93 (custom_item_id), 
-                INDEX IDX_77DE7EF7BEB4F98 (parent_custom_item_id), 
+                {$this->generateIndexStatement($this->table, ['custom_item_id'])},
+                {$this->generateIndexStatement($this->table, ['parent_custom_item_id'])},
                 PRIMARY KEY(custom_item_id, parent_custom_item_id)
             ) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB
         ");
 
-        $this->addSql("ALTER TABLE {$this->tablePrefix}custom_item_xref_custom_item 
-            ADD CONSTRAINT FK_77DE7EF715363B93 
-            FOREIGN KEY (custom_item_id) 
-            REFERENCES {$this->tablePrefix}custom_item (id) ON DELETE CASCADE
-        ");
+        $this->addSql($this->generateAlterTableForeignKeyStatement(
+            $this->table,
+            ['custom_item_id'],
+            'custom_item',
+            ['id'],
+            'ON DELETE CASCADE'
+        ));
 
-        $this->addSql("ALTER TABLE {$this->tablePrefix}custom_item_xref_custom_item 
-            ADD CONSTRAINT FK_77DE7EF7BEB4F98 
-            FOREIGN KEY (parent_custom_item_id) 
-            REFERENCES {$this->tablePrefix}custom_item (id) ON DELETE CASCADE
-        ");
+        $this->addSql($this->generateAlterTableForeignKeyStatement(
+            $this->table,
+            ['parent_custom_item_id'],
+            'custom_item',
+            ['id'],
+            'ON DELETE CASCADE'
+        ));
     }
 }


### PR DESCRIPTION
> doctrine uses the table name to generate the index name. Thus table prefixes cause different index names leading to migrations failing or being different when running update schema

Discussion: https://mautic.slack.com/archives/G5EDKF3MM/p1552381868253100