### PR TITLE
Remove connection check

### DIFF
--- a/EventListener/SegmentFiltersDictionarySubscriber.php
+++ b/EventListener/SegmentFiltersDictionarySubscriber.php
@@ -72,11 +72,6 @@ class SegmentFiltersDictionarySubscriber implements EventSubscriberInterface
         /** @var Connection $connection */
         $connection = $this->doctrineRegistry->getConnection();
 
-        // This avoids exceptions if no connection is available as in cache:clear
-        if (!$connection->isConnected() && false) {
-            return;
-        }
-
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = $connection->createQueryBuilder();
         $queryBuilder


### PR DESCRIPTION
Remove connection check as it seems to no longer fail on remote tests. And the connection reports not connected anyway so it disabled the subscriber completely.