### PR TITLE
Required Fields in custom objects are not being required

### DIFF
--- a/Form/Type/CustomItemType.php
+++ b/Form/Type/CustomItemType.php
@@ -52,7 +52,6 @@ class CustomItemType extends AbstractType
                     'customItem' => $builder->getData(),
                 ],
                 'label'      => false,
-                'required'   => false,
             ]
         );
 


### PR DESCRIPTION
Required fields in custom objects fields are not being required when saving a custom item