### PR TITLE
Fix default value label in modal for CF form

### DIFF
--- a/Form/Type/CustomFieldType.php
+++ b/Form/Type/CustomFieldType.php
@@ -325,6 +325,11 @@ class CustomFieldType extends AbstractType
             // Nothing to do
         }
 
+        if ($isModal) {
+            // Do not use defined label in modal form
+            $options['label'] = 'custom.field.label.default_value';
+        }
+
         // Demo field in panel
         $form->add(
             'defaultValue',


### PR DESCRIPTION
I didn't created a issue for this.
In CF modal was shown label for default value defined in label field above. Now it is using `Default value` translated string again.