### PR TITLE
Fix empty values for Date & DateTime in CI form

### DIFF
--- a/CustomFieldType/DataTransformer/ViewDateTransformer.php
+++ b/CustomFieldType/DataTransformer/ViewDateTransformer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2019 Mautic, Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\CustomObjectsBundle\CustomFieldType\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+
+class ViewDateTransformer implements DataTransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value)
+    {
+        if ('' === $value) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (null === $value) {
+            return '';
+        }
+
+        return $value;
+    }
+}

--- a/Form/Type/CustomFieldValueType.php
+++ b/Form/Type/CustomFieldValueType.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Form\Type;
 
+use MauticPlugin\CustomObjectsBundle\CustomFieldType\DataTransformer\ViewDateTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use MauticPlugin\CustomObjectsBundle\Entity\CustomFieldValueInterface;
@@ -33,12 +36,23 @@ class CustomFieldValueType extends AbstractType
         $customFieldValue = $customItem->findCustomFieldValueForFieldId($customFieldId);
         $customField      = $customFieldValue->getCustomField();
         $options          = ['empty_data'  => $customItem->getId() ? null : $customField->getDefaultValue()];
+        $symfonyFormType  =  $customField->getTypeObject()->getSymfonyFormFieldType();
 
-        $builder->add(
-            'value',
-            $customField->getTypeObject()->getSymfonyFormFieldType(),
-            $customField->getFormFieldOptions($options)
-        );
+        if (DateType::class === $symfonyFormType || DateTimeType::class === $symfonyFormType) {
+            $builder->add(
+                $builder->create(
+                    'value',
+                    $customField->getTypeObject()->getSymfonyFormFieldType(),
+                    $customField->getFormFieldOptions($options)
+                )->addViewTransformer(new ViewDateTransformer())
+            );
+        } else {
+            $builder->add(
+                'value',
+                $customField->getTypeObject()->getSymfonyFormFieldType(),
+                $customField->getFormFieldOptions($options)
+            );
+        }
     }
 
     /**

--- a/Tests/Unit/CustomFieldType/DataTransformer/ViewDateTransformerTest.php
+++ b/Tests/Unit/CustomFieldType/DataTransformer/ViewDateTransformerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2019 Mautic, Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Unit\CustomFieldType\DataTransformer;
+
+use MauticPlugin\CustomObjectsBundle\CustomFieldType\DataTransformer\ViewDateTransformer;
+
+class ViewDateTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    private const VAL = 'value';
+
+    public function testTransform(): void
+    {
+        $transformer = new ViewDateTransformer();
+
+        $this->assertNull($transformer->transform(''));
+        $this->assertSame(self::VAL, $transformer->transform(self::VAL));
+    }
+
+    public function testReverseTransform(): void
+    {
+        $transformer = new ViewDateTransformer();
+
+        $this->assertSame('', $transformer->reverseTransform(null));
+        $this->assertSame(self::VAL, $transformer->reverseTransform(self::VAL));
+    }
+}


### PR DESCRIPTION
Fix saving empty Date and DateTime values.
Not sure about transformer injection in `Form/Type/CustomFieldValueType` - failing test there.
It is ready for further discussion tomorrow