### PR TITLE
Added missing dependency of a service

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -989,7 +989,7 @@ return [
             ],
             'mautic.lead.query.builder.custom_item.value'  => [
                 'class'     => \MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\CustomItemFilterQueryBuilder::class,
-                'arguments' => ['mautic.lead.model.random_parameter_name'],
+                'arguments' => ['mautic.lead.model.random_parameter_name', 'custom_object.query.filter.helper'],
             ],
             'custom_object.query.filter.helper'            => [
                 'class'     => \MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper::class,


### PR DESCRIPTION
@galvani somehow forgot to add a dependency to a service. It's odd that the functional tests for segments did not catch that.

https://github.com/mautic-inc/plugin-custom-objects/blob/master/Segment/Query/Filter/CustomItemFilterQueryBuilder.php#L35