### PR TITLE
We must reset offset and limit for count queries to work

### DIFF
--- a/Model/CustomItemModel.php
+++ b/Model/CustomItemModel.php
@@ -273,6 +273,9 @@ class CustomItemModel extends FormModel
     {
         $queryBuilder = $this->createListOrmQueryBuilder($tableConfig);
         $queryBuilder->select($queryBuilder->expr()->countDistinct(CustomItem::TABLE_ALIAS));
+        $queryBuilder->setMaxResults(1);
+        $queryBuilder->setFirstResult(0);
+        $queryBuilder->resetDQLPart('orderBy');
 
         $this->dispatcher->dispatch(
             CustomItemEvents::ON_CUSTOM_ITEM_LIST_ORM_QUERY,

--- a/Model/CustomObjectModel.php
+++ b/Model/CustomObjectModel.php
@@ -225,6 +225,9 @@ class CustomObjectModel extends FormModel
     {
         $queryBuilder = $this->createListQueryBuilder($tableConfig);
         $queryBuilder->select($queryBuilder->expr()->countDistinct(CustomObject::TABLE_ALIAS));
+        $queryBuilder->setMaxResults(1);
+        $queryBuilder->setFirstResult(0);
+        $queryBuilder->resetDQLPart('orderBy');
 
         return (int) $queryBuilder->getQuery()->getSingleScalarResult();
     }

--- a/Tests/Unit/Model/CustomItemModelTest.php
+++ b/Tests/Unit/Model/CustomItemModelTest.php
@@ -434,7 +434,7 @@ class CustomItemModelTest extends \PHPUnit_Framework_TestCase
     public function testGetCountForTable(): void
     {
         $expr        = $this->createMock(Expr::class);
-        $tableConfig = new TableConfig(10, 1, 'column');
+        $tableConfig = new TableConfig(10, 2, 'column');
         $tableConfig->addParameter('customObjectId', 44);
 
         $this->customItemPermissionProvider->expects($this->once())
@@ -451,6 +451,18 @@ class CustomItemModelTest extends \PHPUnit_Framework_TestCase
                 [CustomItem::TABLE_ALIAS],
                 ['the select count expr']
             );
+
+        $this->queryBuilder->expects($this->exactly(2))
+            ->method('setMaxResults')
+            ->withConsecutive([10], [1]);
+
+        $this->queryBuilder->expects($this->exactly(2))
+            ->method('setFirstResult')
+            ->withConsecutive([10], [0]);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('resetDQLPart')
+            ->with('orderBy');
 
         $this->queryBuilder->expects($this->once())
             ->method('expr')

--- a/Tests/Unit/Model/CustomObjectModelTest.php
+++ b/Tests/Unit/Model/CustomObjectModelTest.php
@@ -489,7 +489,7 @@ class CustomObjectModelTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCountForTable(): void
     {
-        $tableConfig = new TableConfig(10, 1, 'column');
+        $tableConfig = new TableConfig(10, 3, 'column');
         $expr        = $this->createMock(Expr::class);
 
         $tableConfig->addParameter('search', 'Unicorn');
@@ -508,6 +508,18 @@ class CustomObjectModelTest extends \PHPUnit_Framework_TestCase
                 [CustomObject::TABLE_ALIAS],
                 ['the select count expr']
             );
+
+        $this->queryBuilder->expects($this->exactly(2))
+            ->method('setMaxResults')
+            ->withConsecutive([10], [1]);
+
+        $this->queryBuilder->expects($this->exactly(2))
+            ->method('setFirstResult')
+            ->withConsecutive([20], [0]);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('resetDQLPart')
+            ->with('orderBy');
 
         $this->queryBuilder->expects($this->once())
             ->method('expr')


### PR DESCRIPTION
Reset also order for speed improvement.

Steps to test:
- Create at least 11 custom objects so you can go to the page 2 in the CO list.
- Go to the page 2, nothing happens, error is in the logs.
- Repeat for custom items, it behaves the same.

With this PR applied, the pagination works for both.