### PR TITLE
Fix select key/value for radio group

### DIFF
--- a/EventListener/SegmentFiltersChoicesGenerateSubscriber.php
+++ b/EventListener/SegmentFiltersChoicesGenerateSubscriber.php
@@ -108,10 +108,6 @@ class SegmentFiltersChoicesGenerateSubscriber implements EventSubscriberInterfac
                         continue;
                     }
 
-                    $availableOperators = $this->getOperatorChoiceList([
-                        'include' => array_keys($customField->getTypeObject()->getOperators()),
-                    ]);
-
                     $allowedOperators = $customField->getTypeObject()->getOperators();
                     $availableOperators = $this->getOperatorsForFieldType($customField->getType());
                     $operators = array_intersect_key($availableOperators, $allowedOperators);


### PR DESCRIPTION
Bug addressed: https://github.com/mautic-inc/mautic-internal/issues/1765

This PR flips the values for select as currently key was the label. This may have impact on other select-able types, so it needs to be thoroughly tested and reviewed.
