### PR TITLE
Make empty segment filter work correctly

### DIFF
--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -60,6 +60,7 @@ class QueryFilterHelper
         $fieldType         = $fieldType ?: $this->getCustomFieldType($queryBuilder, $fieldId);
         $valueQueryBuilder = $this->getBasicItemQueryBuilder($queryBuilder, $builderAlias);
         $this->addCustomFieldValueJoin($valueQueryBuilder, $builderAlias, $fieldType, $fieldId);
+
         return $valueQueryBuilder;
     }
 
@@ -272,9 +273,11 @@ class QueryFilterHelper
                     $customQuery->expr()->isNotNull($tableAlias.'_value.value'),
                     $customQuery->expr()->neq($tableAlias.'_value.value', $customQuery->expr()->literal(''))
                 );
+
                 break;
             case 'notEmpty':
                 $expression = $customQuery->expr()->isNotNull($tableAlias.'_value.value');
+
                 break;
             case 'notIn':
             case '!multiselect':
@@ -382,6 +385,7 @@ class QueryFilterHelper
      * @param int          $fieldId
      *
      * @return QueryBuilder
+     *
      * @throws NotFoundException
      */
     private function addCustomFieldValueJoin(
@@ -403,6 +407,7 @@ class QueryFilterHelper
         );
 
         $customFieldQueryBuilder->setParameter("{$alias}_custom_field_id", $fieldId);
+
         return $customFieldQueryBuilder;
     }
 


### PR DESCRIPTION
## Fixes

 https://github.com/mautic-inc/mautic-internal/issues/1781

## Read description for testing instructions.

## Resulting SQL

```sql
WHERE (NOT EXISTS(SELECT cfwq_11_contact.contact_id as lead_id
                        FROM mautic_custom_item_xref_contact cfwq_11_contact
                                 LEFT JOIN mautic_custom_item cfwq_11_item
                                           ON cfwq_11_item.id = cfwq_11_contact.custom_item_id
                                 LEFT JOIN mautic_custom_field_value_text cfwq_11_value
                                           ON (cfwq_11_value.custom_item_id = cfwq_11_item.id) AND
                                              (cfwq_11_value.custom_field_id = :cfwq_11_custom_field_id)
                        WHERE ((cfwq_11_value.value IS NOT NULL) AND (cfwq_11_value.value <> ''))
                          AND (l.id = cfwq_11_contact.contact_id)))
        AND (WnYUmtAC.lead_id IS NULL)
```