### PR TITLE
Fix phpunit config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "autoload.php" >
 
     <testsuites>


### PR DESCRIPTION
Fixing phpunit configuration

1. The attribute 'syntaxCheck' is not allowed.