### PR TITLE
MAUT-3518 Select/Multiselect box label/value fix for custom items form fields

### DIFF
--- a/Entity/CustomField.php
+++ b/Entity/CustomField.php
@@ -419,7 +419,7 @@ class CustomField extends FormEntity implements UniqueEntityInterface
             $choices = $this->getTypeObject()->getChoices();
         } else {
             foreach ($this->getOptions() as $option) {
-                $choices[$option->getValue()] = $option->getLabel();
+                $choices[$option->getLabel()] = $option->getValue();
             }
         }
 
@@ -434,12 +434,13 @@ class CustomField extends FormEntity implements UniqueEntityInterface
     public function valueToLabel(string $value): string
     {
         $choices = $this->getChoices();
+        $label   = array_search($value, $choices, true);
 
-        if (isset($choices[$value])) {
-            return $choices[$value];
+        if ($label === false) {
+            throw new NotFoundException("Label was not found for value {$value}");
         }
-
-        throw new NotFoundException("Label was not found for value {$value}");
+        
+        return $label;
     }
 
     /**

--- a/Tests/Unit/Entity/CustomFieldTest.php
+++ b/Tests/Unit/Entity/CustomFieldTest.php
@@ -229,10 +229,10 @@ class CustomFieldTest extends \PHPUnit\Framework\TestCase
             $this->createMock(FilterOperatorProviderInterface::class)
         );
 
-        $red->setLabel('Red');
-        $red->setValue('red');
-        $blue->setLabel('Blue');
-        $blue->setValue('blue');
+        $red->setLabel('Red label');
+        $red->setValue('red value');
+        $blue->setLabel('Blue label');
+        $blue->setValue('blue value');
 
         $customField->setTypeObject($typeObject);
         $customField->setLabel('Colors');
@@ -251,8 +251,8 @@ class CustomFieldTest extends \PHPUnit\Framework\TestCase
                 'data-placeholder' => 'Select one',
             ],
             'choices'    => [
-                'red'  => 'Red',
-                'blue' => 'Blue',
+                'Red label' => 'red value',
+                'Blue label' => 'blue value',
             ],
         ];
 
@@ -269,10 +269,10 @@ class CustomFieldTest extends \PHPUnit\Framework\TestCase
         $optionA = new CustomFieldOption();
         $optionB = new CustomFieldOption();
 
-        $optionA->setLabel('Option A');
-        $optionA->setValue('option_a');
-        $optionB->setLabel('Option B');
-        $optionB->setValue('option_b');
+        $optionA->setLabel('Option A label');
+        $optionA->setValue('option_a_value');
+        $optionB->setLabel('Option B label');
+        $optionB->setValue('option_b_value');
 
         $customField = new CustomField();
         $customField->addOption($optionA);
@@ -285,8 +285,8 @@ class CustomFieldTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertSame([
-            'option_a' => 'Option A',
-            'option_b' => 'Option B',
+             'Option A label' => 'option_a_value',
+             'Option B label' => 'option_b_value',
         ], $customField->getChoices());
     }
 


### PR DESCRIPTION
~~Fix for https://backlog.acquia.com/browse/MAUT-3518 started during debugging another task, stoped as it's not the priority right now.~~

Issue https://backlog.acquia.com/browse/MAUT-3518

Reproduction steps:
1. Create a new custom object
2. Add a select box custom field to it with some options with different keys and labels
3. Add multiselect in the same way
![Snímek obrazovky 2020-04-01 v 18 11 57](https://user-images.githubusercontent.com/12815758/78160492-53c15a00-7444-11ea-9609-1723311afceb.png)

4. Create a custom item.
![Snímek obrazovky 2020-04-01 v 18 11 57](https://user-images.githubusercontent.com/12815758/78160529-6176df80-7444-11ea-81e3-0bfea31e709f.png)

5. Select value not saved
6. Multiselect has validation problem - `Value '1l' does not exist in the list of options of field 'multiselect' (multiselect). Possible values: 1v,2v`
7. Make sure segment filters based on select and multiselect custom object fields still work.

This PR fixes 5th & 6th step