### PR TITLE
MAUT-3519 Fix segment operator building

### DIFF
--- a/EventListener/SegmentFiltersChoicesGenerateSubscriber.php
+++ b/EventListener/SegmentFiltersChoicesGenerateSubscriber.php
@@ -100,7 +100,7 @@ class SegmentFiltersChoicesGenerateSubscriber implements EventSubscriberInterfac
                     }
 
                     $allowedOperators = $customField->getTypeObject()->getOperators();
-                    $availableOperators = $this->getOperatorsForFieldType($customField->getType());
+                    $availableOperators = array_flip($this->getOperatorsForFieldType($customField->getType()));
                     $operators = array_intersect_key($availableOperators, $allowedOperators);
 
                     $event->addChoice(


### PR DESCRIPTION
https://backlog.acquia.com/browse/MAUT-3519

Reproduction
1. Try to select custom object in in segment filter
2. operators are not available
![Snímek obrazovky 2020-04-02 v 12 35 01](https://user-images.githubusercontent.com/12815758/78239771-6d16e480-74de-11ea-9b20-83687a481c0f.png)

This PR fixes step operator availability in select field. 
![Snímek obrazovky 2020-04-02 v 12 33 31](https://user-images.githubusercontent.com/12815758/78239602-3214b100-74de-11ea-9ae6-aaf4edffc2b8.png)

3. Try to save and reload page.

I leaved test case as it is. I found that writing coverage for created objects and anonymous content has no value at this time because of complexity. That's probably why it wasn't done before