### PR TITLE
Search for custom object items

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -19,7 +19,7 @@ use MauticPlugin\CustomObjectsBundle\Provider\CustomObjectRouteProvider;
 return [
     'name'        => 'Custom Objects',
     'description' => 'Adds custom objects and fields features to Mautic',
-    'version'     => '0.0.11',
+    'version'     => '0.0.12',
     'author'      => 'Mautic, Inc.',
 
     'routes' => [

--- a/Controller/CustomItem/ListController.php
+++ b/Controller/CustomItem/ListController.php
@@ -115,6 +115,7 @@ class ListController extends CommonController
         $this->sessionProvider->setPageLimit($limit);
         $this->sessionProvider->setFilter($search);
 
+        $route    = $this->routeProvider->buildListRoute($objectId, $page);
         $response = [
             'viewParameters' => [
                 'searchValue'      => $search,
@@ -130,15 +131,14 @@ class ListController extends CommonController
             'contentTemplate' => 'CustomObjectsBundle:CustomItem:list.html.php',
             'passthroughVars' => [
                 'mauticContent' => 'customItem',
+                'route'         => $route,
             ],
         ];
 
         if ($request->isXmlHttpRequest()) {
             $response['viewParameters']['tmpl'] = $request->get('tmpl', 'index');
         } else {
-            $route                                = $this->routeProvider->buildListRoute($objectId, $page);
-            $response['returnUrl']                = $route;
-            $response['passthroughVars']['route'] = $route;
+            $response['returnUrl'] = $route;
         }
 
         return $this->delegateView($response);

--- a/Entity/CustomFieldValueOption.php
+++ b/Entity/CustomFieldValueOption.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Entity;
 
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 
@@ -22,6 +22,11 @@ use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
  */
 class CustomFieldValueOption extends AbstractCustomFieldValue
 {
+    /**
+     * @var int|null
+     */
+    private $id;
+
     /**
      * @var string[]|string|null
      */
@@ -40,12 +45,23 @@ class CustomFieldValueOption extends AbstractCustomFieldValue
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
         $builder = new ClassMetadataBuilder($metadata);
-        $builder->setTable('custom_field_value_option');
+        $builder->setTable('custom_field_value_option')
+            ->addUniqueConstraint(['value', 'custom_field_id', 'custom_item_id'], 'unique')
+            ->addFulltextIndex(['value'], 'value_fulltext');
 
-        parent::addReferenceColumns($builder);
+        $builder->addBigIntIdField();
 
-        $builder->createField('value', Type::STRING)
-            ->makePrimaryKey()
+        $builder->createManyToOne('customField', CustomField::class)
+            ->addJoinColumn('custom_field_id', 'id', false, false, 'CASCADE')
+            ->fetchExtraLazy()
+            ->build();
+
+        $builder->createManyToOne('customItem', CustomItem::class)
+            ->addJoinColumn('custom_item_id', 'id', false, false, 'CASCADE')
+            ->fetchExtraLazy()
+            ->build();
+
+        $builder->createField('value', Types::STRING)
             ->build();
     }
 

--- a/Entity/CustomFieldValueText.php
+++ b/Entity/CustomFieldValueText.php
@@ -38,8 +38,9 @@ class CustomFieldValueText extends AbstractCustomFieldValue
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
         $builder = new ClassMetadataBuilder($metadata);
-        $builder->setTable('custom_field_value_text');
-        $builder->addNullableField('value', Type::TEXT);
+        $builder->setTable('custom_field_value_text')
+            ->addNullableField('value', Type::TEXT)
+            ->addFulltextIndex(['value'], 'value_fulltext');
 
         parent::addReferenceColumns($builder);
     }

--- a/Entity/CustomItem.php
+++ b/Entity/CustomItem.php
@@ -100,7 +100,8 @@ class CustomItem extends FormEntity implements UniqueEntityInterface
         $builder = new ClassMetadataBuilder($metadata);
 
         $builder->setTable(self::TABLE_NAME)
-            ->setCustomRepositoryClass(CustomItemRepository::class);
+            ->setCustomRepositoryClass(CustomItemRepository::class)
+            ->addFulltextIndex(['name'], 'name_fulltext');
 
         $builder->createManyToOne('customObject', CustomObject::class)
             ->addJoinColumn('custom_object_id', 'id', false, false, 'CASCADE')

--- a/Migrations/Version_0_0_12.php
+++ b/Migrations/Version_0_0_12.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use Mautic\IntegrationsBundle\Migration\AbstractMigration;
+
+class Version_0_0_12 extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function isApplicable(Schema $schema): bool
+    {
+        try {
+            return !$schema->getTable($this->concatPrefix('custom_item'))->hasIndex('name_fulltext');
+        } catch (SchemaException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function up(): void
+    {
+        $this->addSql("CREATE FULLTEXT INDEX name_fulltext ON {$this->concatPrefix('custom_item')} (name)");
+        $this->addSql("CREATE FULLTEXT INDEX value_fulltext ON {$this->concatPrefix('custom_field_value_text')} (value)");
+        $this->addSql("CREATE FULLTEXT INDEX value_fulltext ON {$this->concatPrefix('custom_field_value_option')} (value)");
+        $this->addSql("ALTER TABLE {$this->concatPrefix('custom_field_value_option')} ADD id BIGINT UNSIGNED AUTO_INCREMENT NOT NULL, DROP PRIMARY KEY, ADD PRIMARY KEY (id)");
+        $this->addSql("CREATE UNIQUE INDEX `unique` ON {$this->concatPrefix('custom_field_value_option')} (value, custom_field_id, custom_item_id)");
+    }
+}

--- a/Tests/Functional/Controller/CustomItemListControllerSearchTest.php
+++ b/Tests/Functional/Controller/CustomItemListControllerSearchTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use MauticPlugin\CustomObjectsBundle\Entity\AbstractCustomFieldValue;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomFieldValueOption;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomFieldValueText;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomItem;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+class CustomItemListControllerSearchTest extends MauticMysqlTestCase
+{
+    public function testSearchItemName(): void
+    {
+        $customObject    = $this->createCustomObject();
+        $customItemFound = $this->createCustomItem($customObject, 'Latitude E7000');
+        $this->createCustomItem($customObject, 'MacBook Pro');
+        $this->em->flush();
+
+        $this->assertFound($customObject, $customItemFound, 'E700');
+    }
+
+    public function testSearchFieldValueText(): void
+    {
+        $customObject       = $this->createCustomObject();
+        $customItemNotFound = $this->createCustomItem($customObject, 'MacBook Pro');
+        $customItemFound    = $this->createCustomItem($customObject, 'Latitude E7000');
+
+        $customField = new CustomField();
+        $customField->setLabel('Brand');
+        $customField->setType('text');
+        $customField->setAlias('brand');
+        $customObject->addCustomField($customField);
+
+        $this->addCustomFieldValue($customItemNotFound, new CustomFieldValueText($customField, $customItemNotFound, 'Apple'));
+        $this->addCustomFieldValue($customItemFound, new CustomFieldValueText($customField, $customItemFound, 'Dell Inc.'));
+
+        $this->em->flush();
+
+        $this->assertFound($customObject, $customItemFound, 'inc');
+    }
+
+    public function testSearchFieldValueOption(): void
+    {
+        $customObject       = $this->createCustomObject();
+        $customItemNotFound = $this->createCustomItem($customObject, 'MacBook Pro');
+        $customItemFound    = $this->createCustomItem($customObject, 'Latitude E7000');
+
+        $customField = new CustomField();
+        $customField->setLabel('Size');
+        $customField->setType('multiselect');
+        $customField->setAlias('size');
+        $customObject->addCustomField($customField);
+
+        $this->createCustomFieldOption($customField, 'Small size', 'size small', 0);
+        $this->createCustomFieldOption($customField, 'Medium size', 'size medium', 1);
+
+        $this->addCustomFieldValue($customItemNotFound, new CustomFieldValueOption($customField, $customItemNotFound, 'size small'));
+        $this->addCustomFieldValue($customItemFound, new CustomFieldValueOption($customField, $customItemFound, 'size medium'));
+
+        $this->em->flush();
+
+        $this->assertFound($customObject, $customItemFound, 'medi');
+    }
+
+    private function createCustomObject(): CustomObject
+    {
+        $customObject = new CustomObject();
+        $customObject->setNameSingular('Device');
+        $customObject->setNamePlural('Devices');
+        $customObject->setAlias('devices');
+        $this->em->persist($customObject);
+
+        return $customObject;
+    }
+
+    private function createCustomItem(CustomObject $customObject, string $name): CustomItem
+    {
+        $customItem = new CustomItem($customObject);
+        $customItem->setName($name);
+        $this->em->persist($customItem);
+
+        return $customItem;
+    }
+
+    private function createCustomFieldOption(CustomField $customField, string $label, string $value, int $order): CustomFieldOption
+    {
+        $customFieldOption = new CustomFieldOption();
+        $customFieldOption->setCustomField($customField);
+        $customFieldOption->setLabel($label);
+        $customFieldOption->setValue($value);
+        $customFieldOption->setOrder($order);
+        $this->em->persist($customFieldOption);
+
+        return $customFieldOption;
+    }
+
+    private function addCustomFieldValue(CustomItem $customItem, AbstractCustomFieldValue $customFieldValue): void
+    {
+        $customItem->addCustomFieldValue($customFieldValue);
+        $this->em->persist($customFieldValue);
+    }
+
+    private function assertFound(CustomObject $customObject, CustomItem $customItem, string $search): void
+    {
+        $crawler      = $this->client->request(Request::METHOD_GET, sprintf('/s/custom/object/%s/item?search=%s', $customObject->getId(), $search));
+        $tableCrawler = $crawler->filterXPath('//h3[contains(text(), "Devices")]/following::table[1]');
+        Assert::assertSame(1, $tableCrawler->count());
+
+        $rowCrawler = $tableCrawler->filterXPath('.//tbody/tr');
+        Assert::assertSame(1, $rowCrawler->count());
+
+        $cellCrawler = $rowCrawler->filter('td');
+        Assert::assertSame($customItem->getName(), trim($cellCrawler->eq(1)->text()));
+        Assert::assertSame((string) $customItem->getId(), trim($cellCrawler->eq(2)->text()));
+    }
+}

--- a/Tests/Functional/EventListener/ImportSubscriberTest.php
+++ b/Tests/Functional/EventListener/ImportSubscriberTest.php
@@ -99,7 +99,7 @@ class ImportSubscriberTest extends KernelTestCase
         $expectedValues                   = $csvRow;
         $expectedValues['datetime']       = new \DateTimeImmutable('2019-03-04 12:35:09');
         $expectedValues['date']           = new \DateTimeImmutable('2019-03-04 00:00:00');
-        $expectedValues['multiselect']    = ['option_a', 'option_b'];
+        $expectedValues['multiselect']    = ['option_b', 'option_a'];
 
         // Import the custom item
         $insertStatus = $this->importCsvRow($customObject, $csvRow);
@@ -137,7 +137,7 @@ class ImportSubscriberTest extends KernelTestCase
         $expectedUpdatedValues                   = $editCsvRow;
         $expectedUpdatedValues['datetime']       = new \DateTimeImmutable('2019-03-04 12:35:09');
         $expectedUpdatedValues['date']           = new \DateTimeImmutable('2019-05-24 00:00:00');
-        $expectedUpdatedValues['multiselect']    = ['option_a', 'option_b'];
+        $expectedUpdatedValues['multiselect']    = ['option_b', 'option_a'];
 
         $this->assertTrue($updateStatus);
 

--- a/Views/CustomItem/index.html.php
+++ b/Views/CustomItem/index.html.php
@@ -20,9 +20,9 @@ $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actio
     <?php echo $view->render(
     'MauticCoreBundle:Helper:list_toolbar.html.php',
     [
-            // 'searchValue' => $searchValue,
-            // 'action'      => $currentRoute,
-        ]
+        'searchValue' => $searchValue,
+        'action'      => $currentRoute,
+    ]
 ); ?>
     <div class="page-list">
         <?php $view['slots']->output('_content'); ?>


### PR DESCRIPTION
https://backlog.acquia.com/browse/MAUT-3543

#### Description:
This PR adds custom item search across its name, text field values and multi-select field values.

#### Steps to test this PR:
1. Switch to Mautic cloud [MAUT-3543](https://github.com/mautic-inc/mautic-cloud/tree/MAUT-3543) branch as it contains Fulltext support.
2. Create some custom object items with some text field values and multi-select field values.
3. Go to custom object item list and try searching for some value.
4. Relevant custom object items should be filtered out.