### PR TITLE
MAUT-3723: CO type error during segment build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/*
 /Tests/Coverage/*
-/.idea/*
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/*
 /Tests/Coverage/*
+/.idea/*

--- a/Segment/Query/Filter/CustomItemNameFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomItemNameFilterQueryBuilder.php
@@ -65,7 +65,7 @@ class CustomItemNameFilterQueryBuilder extends BaseFilterQueryBuilder
             $filterQueryBuilder,
             $tableAlias,
             $filter->getOperator(),
-            $filter->getParameterValue()
+            (string) $filter->getParameterValue()
         );
 
         $filterQueryBuilder->select($tableAlias.'_contact.contact_id as lead_id');

--- a/Tests/Unit/Helper/QueryFilterHelperTest.php
+++ b/Tests/Unit/Helper/QueryFilterHelperTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Unit\Helper;
+
+use Mautic\LeadBundle\Segment\Query\Expression\ExpressionBuilder;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
+use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class QueryFilterHelperTest extends TestCase
+{
+    /**
+     * @var QueryFilterHelper
+     */
+    private $queryFilterHelper;
+
+    /**
+     * @var QueryBuilder|MockObject
+     */
+    private $queryBuilder;
+
+    /**
+     * @var ExpressionBuilder|MockObject
+     */
+    private $expressionBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $customFieldTypeProvider = $this->createMock(CustomFieldTypeProvider::class);
+        $this->queryFilterHelper = new QueryFilterHelper($customFieldTypeProvider);
+        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->expressionBuilder = $this->createMock(ExpressionBuilder::class);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testAddCustomObjectNameExpression(): void
+    {
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('expr')
+            ->willReturn($this->expressionBuilder);
+
+        $this->expressionBuilder
+            ->expects($this->any())
+            ->method('eq')
+            ->willReturn($this->expressionBuilder);
+
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('andWhere')
+            ->with($this->expressionBuilder);
+
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('setParameter')
+            ->with('test_value_value', 'acquia', null);
+
+        $this->queryFilterHelper
+            ->addCustomObjectNameExpression($this->queryBuilder, 'test', 'eq', 'acquia');
+    }
+
+    public function testAddCustomObjectNameExpressionWithErrorForIntegerValue(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('expr')
+            ->willReturn($this->expressionBuilder);
+
+        $this->expressionBuilder
+            ->expects($this->any())
+            ->method('eq')
+            ->willReturn($this->expressionBuilder);
+
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('andWhere')
+            ->with($this->expressionBuilder);
+
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('setParameter')
+            ->with('test_value_value', 10, null);
+
+        $this->queryFilterHelper
+            ->addCustomObjectNameExpression($this->queryBuilder, 'test', 'eq', 10);
+    }
+}

--- a/Tests/Unit/Helper/QueryFilterHelperTest.php
+++ b/Tests/Unit/Helper/QueryFilterHelperTest.php
@@ -32,8 +32,7 @@ class QueryFilterHelperTest extends TestCase
     {
         parent::setUp();
 
-        $customFieldTypeProvider = $this->createMock(CustomFieldTypeProvider::class);
-        $this->queryFilterHelper = new QueryFilterHelper($customFieldTypeProvider);
+        $this->queryFilterHelper = new QueryFilterHelper(new CustomFieldTypeProvider());
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->expressionBuilder = $this->createMock(ExpressionBuilder::class);
     }

--- a/Tests/Unit/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
+++ b/Tests/Unit/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace MauticPlugin\CustomObjectsBundle\Tests\Unit\Segment\Query\Filter;
 
 use Doctrine\DBAL\Connection;
-use Mautic\LeadBundle\{Segment\ContactSegmentFilter,
-    Segment\Query\Expression\ExpressionBuilder,
-    Segment\Query\Filter\FilterQueryBuilderInterface,
-    Segment\Query\QueryBuilder,
-    Segment\RandomParameterName};
+use Mautic\LeadBundle\Segment\ContactSegmentFilter;
+use Mautic\LeadBundle\Segment\Query\Expression\ExpressionBuilder;
+use Mautic\LeadBundle\Segment\Query\Filter\FilterQueryBuilderInterface;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\RandomParameterName;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
 use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
 use MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\CustomItemNameFilterQueryBuilder;

--- a/Tests/Unit/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
+++ b/Tests/Unit/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Unit\Segment\Query\Filter;
+
+use Doctrine\DBAL\Connection;
+use Mautic\LeadBundle\{Segment\ContactSegmentFilter,
+    Segment\Query\Expression\ExpressionBuilder,
+    Segment\Query\Filter\FilterQueryBuilderInterface,
+    Segment\Query\QueryBuilder,
+    Segment\RandomParameterName};
+use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
+use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
+use MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\CustomItemNameFilterQueryBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class CustomItemNameFilterQueryBuilderTest extends TestCase
+{
+    /**
+     * @var FilterQueryBuilderInterface
+     */
+    private $customItemNameFilterQueryBuilder;
+
+    /**
+     * @var QueryBuilder|MockObject
+     */
+    private $queryBuilder;
+
+    /**
+     * @var ContactSegmentFilter|MockObject
+     */
+    private $contactSegmentFilter;
+
+    /**
+     * @var Connection|MockObject
+     */
+    private $connection;
+
+    /**
+     * @var ExpressionBuilder|MockObject
+     */
+    private $expressionBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+
+        $randomParameter = new RandomParameterName();
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $customFieldTypeProvider = $this->createMock(CustomFieldTypeProvider::class);
+        $queryFilterHelper = new QueryFilterHelper($customFieldTypeProvider);
+        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->contactSegmentFilter = $this->createMock(ContactSegmentFilter::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->expressionBuilder = $this->createMock(ExpressionBuilder::class);
+
+        $this->customItemNameFilterQueryBuilder = new CustomItemNameFilterQueryBuilder(
+            $randomParameter,
+            $queryFilterHelper,
+            $eventDispatcher
+        );
+    }
+
+    public function testApplyQuery(): void
+    {
+        $this->contactSegmentFilter
+            ->expects($this->at(0))
+            ->method("getField")
+            ->willReturn("field1");
+
+        $this->contactSegmentFilter
+            ->expects($this->at(1))
+            ->method("getField")
+            ->willReturn("1");
+
+        $this->contactSegmentFilter
+            ->expects($this->at(2))
+            ->method("getOperator")
+            ->willReturn("eq");
+
+        $this->contactSegmentFilter
+            ->expects($this->at(3))
+            ->method("getParameterValue")
+            ->willReturn("mautic");
+
+        $this->contactSegmentFilter
+            ->expects($this->at(4))
+            ->method("getOperator")
+            ->willReturn("eq");
+
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method("getConnection")
+            ->willReturn($this->connection);
+
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('expr')
+            ->willReturn($this->expressionBuilder);
+
+        $result = $this->customItemNameFilterQueryBuilder->applyQuery($this->queryBuilder, $this->contactSegmentFilter);
+        $this->assertEquals($this->queryBuilder, $result);
+    }
+
+    public function testApplyQueryWithIntegerParameterValue(): void
+    {
+        $this->contactSegmentFilter
+            ->expects($this->at(0))
+            ->method("getField")
+            ->willReturn("field1");
+
+        $this->contactSegmentFilter
+            ->expects($this->at(1))
+            ->method("getField")
+            ->willReturn("1");
+
+        $this->contactSegmentFilter
+            ->expects($this->at(2))
+            ->method("getOperator")
+            ->willReturn("eq");
+
+        $this->contactSegmentFilter
+            ->expects($this->at(3))
+            ->method("getParameterValue")
+            ->willReturn(10);
+
+        $this->contactSegmentFilter
+            ->expects($this->at(4))
+            ->method("getOperator")
+            ->willReturn("eq");
+
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method("getConnection")
+            ->willReturn($this->connection);
+
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('expr')
+            ->willReturn($this->expressionBuilder);
+
+        $result = $this->customItemNameFilterQueryBuilder->applyQuery($this->queryBuilder, $this->contactSegmentFilter);
+        $this->assertEquals($this->queryBuilder, $result);
+    }
+}

--- a/Tests/Unit/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
+++ b/Tests/Unit/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
@@ -51,8 +51,7 @@ class CustomItemNameFilterQueryBuilderTest extends TestCase
 
         $randomParameter = new RandomParameterName();
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $customFieldTypeProvider = $this->createMock(CustomFieldTypeProvider::class);
-        $queryFilterHelper = new QueryFilterHelper($customFieldTypeProvider);
+        $queryFilterHelper = new QueryFilterHelper(new CustomFieldTypeProvider());
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->contactSegmentFilter = $this->createMock(ContactSegmentFilter::class);
         $this->connection = $this->createMock(Connection::class);
@@ -65,7 +64,11 @@ class CustomItemNameFilterQueryBuilderTest extends TestCase
         );
     }
 
-    public function testApplyQuery(): void
+    /**
+     * @dataProvider parameterValueProvider
+     * @param $parameterValue
+     */
+    public function testApplyQuery($parameterValue): void
     {
         $this->contactSegmentFilter
             ->expects($this->at(0))
@@ -85,7 +88,7 @@ class CustomItemNameFilterQueryBuilderTest extends TestCase
         $this->contactSegmentFilter
             ->expects($this->at(3))
             ->method("getParameterValue")
-            ->willReturn("mautic");
+            ->willReturn($parameterValue);
 
         $this->contactSegmentFilter
             ->expects($this->at(4))
@@ -106,44 +109,11 @@ class CustomItemNameFilterQueryBuilderTest extends TestCase
         $this->assertEquals($this->queryBuilder, $result);
     }
 
-    public function testApplyQueryWithIntegerParameterValue(): void
+    public function parameterValueProvider()
     {
-        $this->contactSegmentFilter
-            ->expects($this->at(0))
-            ->method("getField")
-            ->willReturn("field1");
-
-        $this->contactSegmentFilter
-            ->expects($this->at(1))
-            ->method("getField")
-            ->willReturn("1");
-
-        $this->contactSegmentFilter
-            ->expects($this->at(2))
-            ->method("getOperator")
-            ->willReturn("eq");
-
-        $this->contactSegmentFilter
-            ->expects($this->at(3))
-            ->method("getParameterValue")
-            ->willReturn(10);
-
-        $this->contactSegmentFilter
-            ->expects($this->at(4))
-            ->method("getOperator")
-            ->willReturn("eq");
-
-        $this->queryBuilder
-            ->expects($this->any())
-            ->method("getConnection")
-            ->willReturn($this->connection);
-
-        $this->queryBuilder
-            ->expects($this->any())
-            ->method('expr')
-            ->willReturn($this->expressionBuilder);
-
-        $result = $this->customItemNameFilterQueryBuilder->applyQuery($this->queryBuilder, $this->contactSegmentFilter);
-        $this->assertEquals($this->queryBuilder, $result);
+        return [
+          ['mautic'],
+          [10],
+        ];
     }
 }


### PR DESCRIPTION
Fixing Type error in 
```
MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper::addCustomObjectNameExpression()
``` 
when called from 
```
plugins/CustomObjectsBundle/Segment/Query/Filter/CustomItemNameFilterQueryBuilder.php
```

Please see ticket https://backlog.acquia.com/browse/MAUT-3723 for details