### PR TITLE
MAUT-3718: CO email tokens: Display default value if CO was not found.

### DIFF
--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -175,11 +175,11 @@ class TokenSubscriber implements EventSubscriberInterface
         $tokens->map(function (Token $token) use ($event): void {
             try {
                 $customObject = $this->customObjectModel->fetchEntityByAlias($token->getCustomObjectAlias());
+                $fieldValues = $this->getCustomFieldValues($customObject, $token, $event);
             } catch (NotFoundException $e) {
-                return;
+                $fieldValues = null;
             }
 
-            $fieldValues = $this->getCustomFieldValues($customObject, $token, $event);
 
             if (empty($fieldValues)) {
                 $result = $token->getDefaultValue();
@@ -314,6 +314,10 @@ class TokenSubscriber implements EventSubscriberInterface
 
             try {
                 $fieldValue    = $customItem->findCustomFieldValueForFieldAlias($token->getCustomFieldAlias());
+                // If the CO item doesn't have a value, get the default value
+                if ("" == $fieldValue->getValue()) {
+                    $fieldValue->setValue($fieldValue->getCustomField()->getDefaultValue());
+                }
                 $fieldValues[] = $fieldValue->getCustomField()->getTypeObject()->valueToString($fieldValue);
             } catch (NotFoundException $e) {
                 // Custom field not found.


### PR DESCRIPTION
Bug Reported: https://backlog.acquia.com/browse/MAUT-3718

Issue: When CO tokens are used in email, if the CO is not found in the system, it is not using the default value mentioned in the token. Instead, it's showing the full token as it is. 

How to test:

- Go to "Contacts" menu item
- Click on any of the contacts from the list
- Click on "Send email"
- A popup opens up
- From the combo box "Import from an existing template", chose anyone which has a token like 
"{custom-object=fruits:name | where=segment-filter | order=latest | limit=1 | format=default | default=Mango}"
where the particular CO shouldn't be existing in the system
- The email sent should have the item "Mango" instead of the full token