### PR TITLE
MAUT-3979 - Cannot load the campaign condition CO form

### DIFF
--- a/EventListener/CampaignSubscriber.php
+++ b/EventListener/CampaignSubscriber.php
@@ -127,6 +127,12 @@ class CampaignSubscriber implements EventSubscriberInterface
         $customObjects = $this->customObjectModel->fetchAllPublishedEntities();
 
         foreach ($customObjects as $customObject) {
+
+            if ($customObject->getCustomFields()->count() === 0) {
+                // Filter COs without defined custom fields
+                continue;
+            }
+
             $event->addAction("custom_item.{$customObject->getId()}.linkcontact", [
                 'label'           => $this->translator->trans('custom.item.events.link.contact', ['%customObject%' => $customObject->getNameSingular()]),
                 'description'     => $this->translator->trans('custom.item.events.link.contact_descr', ['%customObject%' => $customObject->getNameSingular()]),

--- a/EventListener/CampaignSubscriber.php
+++ b/EventListener/CampaignSubscriber.php
@@ -127,7 +127,6 @@ class CampaignSubscriber implements EventSubscriberInterface
         $customObjects = $this->customObjectModel->fetchAllPublishedEntities();
 
         foreach ($customObjects as $customObject) {
-
             if ($customObject->getCustomFields()->count() === 0) {
                 // Filter COs without defined custom fields
                 continue;

--- a/Form/Type/CampaignConditionFieldValueType.php
+++ b/Form/Type/CampaignConditionFieldValueType.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Form\Type;
 
-use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
 use MauticPlugin\CustomObjectsBundle\Model\CustomFieldModel;
 use MauticPlugin\CustomObjectsBundle\Provider\CustomItemRouteProvider;
 use Symfony\Component\Form\AbstractType;
@@ -68,14 +67,16 @@ class CampaignConditionFieldValueType extends AbstractType
                 'attr'     => [
                     'class' => 'form-control',
                 ],
-                'choice_attr' => array_map(function ($field){
-                    return [
+                'choice_attr' => array_map(
+                    function ($field) {
+                        return [
                         'data-operators'  => json_encode($field->getTypeObject()->getOperatorOptions()),
                         'data-options'    => json_encode($field->getChoices()),
                         'data-field-type' => $field->getType(),
                     ];
-                },
-                $fields)
+                    },
+                    $fields
+                )
             ]
         );
 

--- a/Form/Type/CampaignConditionFieldValueType.php
+++ b/Form/Type/CampaignConditionFieldValueType.php
@@ -68,16 +68,14 @@ class CampaignConditionFieldValueType extends AbstractType
                 'attr'     => [
                     'class' => 'form-control',
                 ],
-                'choice_attr' => function ($fieldId) use ($fields) {
-                    /** @var CustomField $field */
-                    $field = $fields[$fieldId];
-
+                'choice_attr' => array_map(function ($field){
                     return [
                         'data-operators'  => json_encode($field->getTypeObject()->getOperatorOptions()),
                         'data-options'    => json_encode($field->getChoices()),
                         'data-field-type' => $field->getType(),
                     ];
                 },
+                $fields)
             ]
         );
 

--- a/Tests/Unit/Form/Type/CampaignConditionFieldValueTypeTest.php
+++ b/Tests/Unit/Form/Type/CampaignConditionFieldValueTypeTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Unit\Form\Type;
+
+use Mautic\LeadBundle\Provider\FilterOperatorProviderInterface;
+use MauticPlugin\CustomObjectsBundle\CustomFieldType\DateType;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
+use MauticPlugin\CustomObjectsBundle\Form\Type\CampaignConditionFieldValueType;
+use MauticPlugin\CustomObjectsBundle\Model\CustomFieldModel;
+use MauticPlugin\CustomObjectsBundle\Provider\CustomItemRouteProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormConfigBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class CampaignConditionFieldValueTypeTest extends TestCase
+{
+    /**
+     * @var CustomFieldModel|MockObject
+     */
+    private $customFieldModel;
+
+    /**
+     * @var CustomItemRouteProvider|MockObject
+     */
+    private $routeProvider;
+
+    /**
+     * @var MockObject|TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var CampaignConditionFieldValueType
+     */
+    private $form;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->customFieldModel = $this->createMock(CustomFieldModel::class);
+        $this->routeProvider = $this->createMock(CustomItemRouteProvider::class);
+        $this->translator = $this->createMock(TranslatorInterface::class);
+
+        $this->form = new CampaignConditionFieldValueType(
+            $this->customFieldModel,
+            $this->routeProvider,
+            $this->translator
+        );
+    }
+
+    public function testBuildForm()
+    {
+        $filterOperatorProvider = $this->createMock(FilterOperatorProviderInterface::class);
+        $fieldType = new DateType($this->translator, $filterOperatorProvider);
+        $field = new CustomField();
+        $field->setTypeObject($fieldType);
+        $fields = [$field];
+
+        $customObject = new CustomObject();
+        $customObject->addCustomField($field);
+
+        $options['customObject'] = $customObject;
+        $options['data']['field'] = 0;
+
+        $operators = [];
+
+        $this->customFieldModel->expects(self::once())
+            ->method('fetchCustomFieldsForObject')
+            ->with($options['customObject'])
+            ->willReturn($fields);
+
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder
+            ->expects(self::at(0))
+            ->method('add')
+            ->with(
+                    'field',
+                    ChoiceType::class,
+                    [
+                        'required' => true,
+                        'label'    => 'custom.item.field',
+                        'choices'  => $fields,
+                        'attr'     => [
+                            'class' => 'form-control',
+                        ],
+                        'choice_attr' => array_map(
+                            function ($field) {
+                                return [
+                                    'data-operators'  => json_encode($field->getTypeObject()->getOperatorOptions()),
+                                    'data-options'    => json_encode($field->getChoices()),
+                                    'data-field-type' => $field->getType(),
+                                ];
+                            },
+                            $fields
+                        )
+                    ]
+            );
+
+        $builder
+            ->expects(self::at(1))
+            ->method('add')
+            ->with(
+                'operator',
+                ChoiceType::class,
+                [
+                    'required' => true,
+                    'label'    => 'custom.item.operator',
+                    'choices'  => $operators,
+                    'attr'     => ['class' => 'link-custom-item-id'],
+                ]
+            );
+
+        $formConfigBuilder = $this->createMock(FormConfigBuilderInterface::class);
+        $formConfigBuilder
+            ->expects(self::once())
+            ->method('resetViewTransformers');
+
+        $builder
+            ->expects(self::at(2))
+            ->method('get')
+            ->with('operator')
+            ->willReturn($formConfigBuilder);
+
+        $builder
+            ->expects(self::at(3))
+            ->method('add')
+            ->with(
+                'value',
+                TextType::class,
+                [
+                    'required' => true,
+                    'label'    => 'custom.item.field.value',
+                    'attr'     => ['class' => 'form-control'],
+                ]
+            );
+
+        $builder
+            ->expects(self::at(4))
+            ->method('add')
+            ->with(
+                'customObjectId',
+                HiddenType::class,
+                ['data' => $options['customObject']->getId()]
+            );
+
+        $this->form->buildForm($builder, $options);
+    }
+
+    public function testConfigureOptions()
+    {
+        $resolver = $this->createMock(OptionsResolver::class);
+        $resolver->expects(self::once())
+            ->method('setRequired')
+            ->with(['customObject']);
+
+        $this->form->configureOptions($resolver);
+    }
+}

--- a/Tests/Unit/Form/Type/CampaignConditionFieldValueTypeTest.php
+++ b/Tests/Unit/Form/Type/CampaignConditionFieldValueTypeTest.php
@@ -93,9 +93,9 @@ class CampaignConditionFieldValueTypeTest extends TestCase
             ->expects(self::at(0))
             ->method('add')
             ->with(
-                    'field',
-                    ChoiceType::class,
-                    [
+                'field',
+                ChoiceType::class,
+                [
                         'required' => true,
                         'label'    => 'custom.item.field',
                         'choices'  => $fields,


### PR DESCRIPTION
Issue : https://backlog.acquia.com/browse/MAUT-3979

Steps to reproduce:
1. Create empty custom object without custom fields
2. Create condition in campaign builder usin"NameOfObject ... "
<details><summary>you'll get `"PHP Notice - Undefined offset: 0" ....`</summary>

```
[2020-09-22 10:59:00] mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\ContextErrorException: "PHP Notice - Undefined offset: 0" at /var/www/html/plugins/CustomObjectsBundle/Form/Type/CampaignConditionFieldValueType.php line 87 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\ContextErrorException(code: 0): PHP Notice - Undefined offset: 0 at /var/www/html/plugins/CustomObjectsBundle/Form/Type/CampaignConditionFieldValueType.php:87)
[stacktrace]
#0 /var/www/html/plugins/CustomObjectsBundle/Form/Type/CampaignConditionFieldValueType.php(87): Mautic\\CoreBundle\\ErrorHandler\\ErrorHandler->handleError(8, 'PHP Notice - Un...', '/var/www/html/p...', 87, Array)
#1 /var/www/html/vendor/symfony/form/ResolvedFormType.php(126): MauticPlugin\\CustomObjectsBundle\\Form\\Type\\CampaignConditionFieldValueType->buildForm(Object(Ivory\\OrderedForm\\Builder\\OrderedFormBuilder), Array)
#2 /var/www/html/vendor/symfony/form/FormFactory.php(80): Symfony\\Component\\Form\\ResolvedFormType->buildForm(Object(Ivory\\OrderedForm\\Builder\\OrderedFormBuilder), Array)
#3 /var/www/html/vendor/symfony/form/FormBuilder.php(98): Symfony\\Component\\Form\\FormFactory->createNamedBuilder('properties', Object(Ivory\\OrderedForm\\OrderedResolvedFormType), NULL, Array)
#4 /var/www/html/vendor/symfony/form/FormBuilder.php(252): Symfony\\Component\\Form\\FormBuilder->create('properties', 'MauticPlugin\\\\Cu...', Array)
#5 /var/www/html/vendor/symfony/form/FormBuilder.php(199): Symfony\\Component\\Form\\FormBuilder->resolveChildren()
#6 /var/www/html/vendor/symfony/form/FormFactory.php(30): Symfony\\Component\\Form\\FormBuilder->getForm()
#7 /var/www/html/app/bundles/CampaignBundle/Controller/EventController.php(89): Symfony\\Component\\Form\\FormFactory->create('Mautic\\\\Campaign...', Array, Array)
#8 /var/www/html/app/bundles/CoreBundle/Controller/CommonController.php(457): Mautic\\CampaignBundle\\Controller\\EventController->newAction(0, '')
#9 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(151): Mautic\\CoreBundle\\Controller\\CommonController->executeAction('new', 0, 0, '')
#10 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(68): Symfony\\Component\\HttpKernel\\HttpKernel->handleRaw(Object(Symfony\\Component\\HttpFoundation\\Request), 1)
#11 /var/www/html/vendor/symfony/http-kernel/Kernel.php(200): Symfony\\Component\\HttpKernel\\HttpKernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#12 /var/www/html/app/AppKernel.php(136): Symfony\\Component\\HttpKernel\\Kernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#13 /var/www/html/app/middlewares/CORSMiddleware.php(91): AppKernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#14 /var/www/html/app/middlewares/CloudMiddleware.php(78): Mautic\\Middleware\\CORSMiddleware->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#15 /var/www/html/app/middlewares/CatchExceptionMiddleware.php(43): Mautic\\Middleware\\CloudMiddleware->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#16 /var/www/html/app/middlewares/Dev/IpRestrictMiddleware.php(64): Mautic\\Middleware\\CatchExceptionMiddleware->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#17 /var/www/html/app/middlewares/VersionCheckMiddleware.php(52): Mautic\\Middleware\\Dev\\IpRestrictMiddleware->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#18 /var/www/html/app/middlewares/RedirectResponseMiddleware.php(68): Mautic\\Middleware\\VersionCheckMiddleware->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#19 /var/www/html/app/middlewares/TrustMiddleware.php(51): Mautic\\Middleware\\RedirectResponseMiddleware->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#20 /var/www/html/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Mautic\\Middleware\\TrustMiddleware->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)
#21 /var/www/html/vendor/stack/run/src/Stack/run.php(13): Stack\\StackedHttpKernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request))
un(Object(Stack\\StackedHttpKernel)) Stack\
#23 {main}
"}
```
</details>

Steps to test: 
1. Create empty custom object without custom fields
2. Condition in campaign builder "NameOfObject ... " is missing
3. Go to https://john-beta.dev.mautic.net/s/campaigns/new
4. Conditions in campaign builder "NameOfObject ... " are missing