### PR TITLE
MAUT-3988: Show labels instead of keys for select and multiselect fields

### DIFF
--- a/Views/CustomField/value.html.php
+++ b/Views/CustomField/value.html.php
@@ -14,14 +14,16 @@ use MauticPlugin\CustomObjectsBundle\Entity\CustomFieldValueInterface;
 
 /* @var PhpEngine $view */
 /* @var CustomFieldValueInterface $fieldValue */
+
+$customFieldType = $fieldValue->getCustomField()->getType();
 ?>
 <?php if ($fieldValue->getValue() instanceof DateTimeInterface) : ?>
-    <?php if ('date' === $fieldValue->getCustomField()->getType()) : ?>
+    <?php if ('date' === $customFieldType) : ?>
         <?php echo $view['date']->toDate($fieldValue->getValue()); ?>
     <?php else : // This must be 'datetime' field?>
         <?php echo $view['date']->toFull($fieldValue->getValue()); ?>
     <?php endif; ?>
-<?php elseif (in_array($fieldValue->getCustomField()->getType(), ['select', 'multiselect'])) : ?>
+<?php elseif (in_array($customFieldType, ['select', 'multiselect'])) : ?>
     <?php echo $view->escape($fieldValue->getCustomField()->getTypeObject()->valueToString($fieldValue)); ?>
 <?php elseif (is_array($fieldValue->getValue())) : ?>
     <?php echo $view->escape($view['formatter']->arrayToString($fieldValue->getValue())); ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |
| New feature? |
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://backlog.acquia.com/browse/MAUT-3988
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
As a marketer I want to see the labels. Not the keys of the select and multiselect boxes.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new custom object
2. Add a Select box field, multiselect field and a text field to the custom object
3. Create a custom item out of that custom object. Make sure you have different keys and labels for the options.
4. In the custom item detail page click the details button to display all the field values. Notice it displays keys and not labels for the select and multiselect fields
5. In the contact detail page link the custom item with a contact. In the table notice it agains shows keys instead of labels.

#### Steps to test this PR:
1. Repeat steps 1-5 from `Steps to reproduce the bug` section. You should see labels instead of keys now.

#### Other areas of Mautic that may be affected by the change:
No

#### List deprecations along with the new alternative:
No

#### List backwards compatibility breaks:
No