### PR TITLE
MAUT-4569: master_object column in the custom_object table is of wrong type

### DIFF
--- a/Migrations/Version_0_0_18.php
+++ b/Migrations/Version_0_0_18.php
@@ -28,6 +28,10 @@ class Version_0_0_18 extends AbstractMigration
      */
     protected function up(): void
     {
+        if ($this->schema->getTable($this->concatPrefix('custom_object'))->hasForeignKey('FK_9C007FE8594D0CC2')) {
+            $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} DROP FOREIGN KEY FK_9C007FE8594D0CC2;");
+        }
+
         // Dropping that index because we use UNIQ_CO_MASTER_OBJECT index instead.
         if ($this->schema->getTable($this->concatPrefix('custom_object'))->hasIndex('master_object')) {
             $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} DROP INDEX master_object;");
@@ -35,10 +39,6 @@ class Version_0_0_18 extends AbstractMigration
 
         // Fix column type. Sometimes it doesn't match what we have in the Version_0_0_11.php. Version_0_0_11 is not correct.
         $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} CHANGE COLUMN `master_object` `master_object` INT(10) UNSIGNED NULL DEFAULT NULL;");
-
-        if ($this->schema->getTable($this->concatPrefix('custom_object'))->hasForeignKey('FK_9C007FE8594D0CC2')) {
-            $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} DROP FOREIGN KEY FK_9C007FE8594D0CC2;");
-        }
 
         if ($this->schema->getTable($this->concatPrefix('custom_object'))->hasIndex('UNIQ_9C007FE8594D0CC2')) {
             $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} DROP INDEX UNIQ_9C007FE8594D0CC2;");

--- a/Migrations/Version_0_0_18.php
+++ b/Migrations/Version_0_0_18.php
@@ -28,6 +28,14 @@ class Version_0_0_18 extends AbstractMigration
      */
     protected function up(): void
     {
+        // Dropping that index because we use UNIQ_CO_MASTER_OBJECT index instead.
+        if ($this->schema->getTable($this->concatPrefix('custom_object'))->hasIndex('master_object')) {
+            $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} DROP INDEX master_object;");
+        }
+
+        // Fix column type. Sometimes it doesn't match what we have in the Version_0_0_11.php. Version_0_0_11 is not correct.
+        $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} CHANGE COLUMN `master_object` `master_object` INT(10) UNSIGNED NULL DEFAULT NULL;");
+
         if ($this->schema->getTable($this->concatPrefix('custom_object'))->hasForeignKey('FK_9C007FE8594D0CC2')) {
             $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} DROP FOREIGN KEY FK_9C007FE8594D0CC2;");
         }

--- a/Migrations/Version_0_0_18.php
+++ b/Migrations/Version_0_0_18.php
@@ -37,7 +37,7 @@ class Version_0_0_18 extends AbstractMigration
             $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} DROP INDEX master_object;");
         }
 
-        // Fix column type. Sometimes it doesn't match what we have in the Version_0_0_11.php. Version_0_0_11 is not correct.
+        // Fix column type. Sometimes it doesn't match what we have in loadMetadata method. Version_0_0_11 migration is not correct.
         $this->addSql("ALTER TABLE {$this->concatPrefix('custom_object')} CHANGE COLUMN `master_object` `master_object` INT(10) UNSIGNED NULL DEFAULT NULL;");
 
         if ($this->schema->getTable($this->concatPrefix('custom_object'))->hasIndex('UNIQ_9C007FE8594D0CC2')) {


### PR DESCRIPTION
`master_object` column in the `custom_object` table is of wrong type and is causing issue in staging.

#### Steps to reproduce:
1. Checkout staging branch of this repository.
2.  Run `bin/console mautic:plugins:reload`, go to the plugins table and set `Custom Object`'s version to `0.0.17`.
3. Alter the `custom_object` table.
Drop FK_CO_MASTER_OBJECT foreign key (if exists).
Drop UNIQ_CO_RELATIONSHIP_OBJECT index (if exists).
Adjust the `mastet_object` column so that it is **not** UNSIGNED and has `INT(11)` type.
4. Run `bin/console mautic:plugins:reload`. The command will fail with an error (can't create foreign key).

Alternatively this error can be reproduced on `https://ajaystg.dev.mautic.net/`.
If you connect to its database end execute the query below, you will get the same error (can't create foreign key):
```sql
ALTER TABLE
 mautic_custom_object
 ADD CONSTRAINT FK_CO_MASTER_OBJECT FOREIGN KEY (master_object)
 REFERENCES mautic_custom_object (id) ON DELETE CASCADE ON UPDATE RESTRICT;
```

#### Steps to test.
1. Checkout this branch.
2. Repeat steps 2-4 from `Steps to reproduce`.
3. Migrations should run now.
