### PR TITLE
Segment rebuild query optimisation

### DIFF
--- a/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
@@ -46,9 +46,6 @@ class CustomFieldFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * @param  SegmentQueryBuilder  $queryBuilder
-     * @param  ContactSegmentFilter  $filter
-     * @return SegmentQueryBuilder
      * @throws DBALException
      */
     public function applyQuery(SegmentQueryBuilder $queryBuilder, ContactSegmentFilter $filter): SegmentQueryBuilder

--- a/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Segment\Query\Filter;
 
+use Doctrine\DBAL\DBALException;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\Filter\BaseFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder as SegmentQueryBuilder;
@@ -45,10 +46,14 @@ class CustomFieldFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * @throws NotFoundException
+     * @param  SegmentQueryBuilder  $queryBuilder
+     * @param  ContactSegmentFilter  $filter
+     * @return SegmentQueryBuilder
+     * @throws DBALException
      */
     public function applyQuery(SegmentQueryBuilder $queryBuilder, ContactSegmentFilter $filter): SegmentQueryBuilder
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $filterOperator = $filter->getOperator();
 
         $tableAlias = 'cfwq_'.(int) $filter->getField();
@@ -60,7 +65,7 @@ class CustomFieldFilterQueryBuilder extends BaseFilterQueryBuilder
 
         foreach ($unionQueryContainer as $segmentQueryBuilder) {
             $segmentQueryBuilder->andWhere(
-                $segmentQueryBuilder->expr()->eq("{$tableAlias}_contact.contact_id", 'l.id')
+                $segmentQueryBuilder->expr()->eq("{$tableAlias}_contact.contact_id", $leadsTableAlias.'.id')
             );
         }
 

--- a/Segment/Query/Filter/CustomItemNameFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomItemNameFilterQueryBuilder.php
@@ -46,9 +46,6 @@ class CustomItemNameFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * @param  QueryBuilder  $queryBuilder
-     * @param  ContactSegmentFilter  $filter
-     * @return QueryBuilder
      * @throws DBALException
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder

--- a/Segment/Query/Filter/CustomItemNameFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomItemNameFilterQueryBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Segment\Query\Filter;
 
+use Doctrine\DBAL\DBALException;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\Filter\BaseFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
@@ -44,8 +45,15 @@ class CustomItemNameFilterQueryBuilder extends BaseFilterQueryBuilder
         return 'mautic.lead.query.builder.custom_item.value';
     }
 
+    /**
+     * @param  QueryBuilder  $queryBuilder
+     * @param  ContactSegmentFilter  $filter
+     * @return QueryBuilder
+     * @throws DBALException
+     */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $customObjectId = $filter->getField();
 
         $tableAlias = 'cin_'.(int) $filter->getField();
@@ -66,7 +74,7 @@ class CustomItemNameFilterQueryBuilder extends BaseFilterQueryBuilder
         );
 
         $filterQueryBuilder->select($tableAlias.'_contact.contact_id as lead_id');
-        $filterQueryBuilder->andWhere('l.id = '.$tableAlias.'_contact.contact_id');
+        $filterQueryBuilder->andWhere($leadsTableAlias.'.id = '.$tableAlias.'_contact.contact_id');
 
         switch ($filter->getOperator()) {
             case 'empty':

--- a/Tests/Unit/EventListener/FilterOperatorSubscriberTest.php
+++ b/Tests/Unit/EventListener/FilterOperatorSubscriberTest.php
@@ -181,6 +181,7 @@ final class FilterOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
             ->willReturn('withinCustomObjects');
         /** @var \PHPUnit\Framework\MockObject\MockObject|QueryBuilder $queryBuilderMock */
         $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $queryBuilderMock->method('getTableAlias')->willReturn('l');
         $queryBuilderMock->expects($this->once())
             ->method('innerJoin')
             ->with(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://backlog.acquia.com/browse/MAUT-3830
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load DB with more than 100k contacts.
2. Get any one of the existing query for segment rebuild which includes segment membership filters.
3. Load up this PR
4. Get any one of the new query for same above segment query.
5. Compare both queries output and execution time (use limit if necessary) on getitfree DB.
6. Check for other segments as well.

#### Other areas of Mautic that may be affected by the change:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 

Note: This PR needs to be tested along with
[#1133](https://github.com/mautic-inc/mautic-cloud/pull/1133)
[BrightTalkBundle #3](https://github.com/mautic-inc/plugin-brighttalk/pull/3)
[SalesforceBundle #151](https://github.com/mautic-inc/plugin-salesforce/pull/151)
[ZoomBundle #4](https://github.com/mautic-inc/plugin-zoom/pull/4)
