### PR TITLE
Open source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "acquia/mautic-custom-objects",
+    "name": "acquia/mc-cs-plugin-custom-objects",
     "description": "This plugin adds custom objects feature.",
     "type": "mautic-plugin",
     "version": "1.0",
@@ -34,7 +34,7 @@
         "mautic/core-lib": "^4.0"
     },
     "require-dev": {
-        "theofidry/alice-data-fixtures": "^1.1",
+        "theofidry/alice-data-fixtures": "^1.1"
     },
     "minimum-stability": "dev",
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": ">=7.4",
         "ext-mbstring": "*",
-        "mautic/core-lib": "^4.2"
+        "mautic/core-lib": "^4.1"
     },
     "require-dev": {
         "theofidry/alice-data-fixtures": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,9 @@
         "wiki": "https://github.com/acquia/mc-cs-plugin-custom-objects/wiki"
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-mbstring": "*",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^4.2"
     },
     "require-dev": {
         "theofidry/alice-data-fixtures": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     "require-dev": {
         "theofidry/alice-data-fixtures": "^1.1"
     },
-    "minimum-stability": "dev",
     "scripts": {
         "test": [
             "@phpunit",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "acquia/mc-cs-plugin-custom-objects",
     "description": "This plugin adds custom objects feature.",
     "type": "mautic-plugin",
-    "version": "1.0",
     "config": {
         "process-timeout": 2000
     },

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,20 @@
 {
-    "name": "mautic/custom-objects-bundle",
+    "name": "acquia/mautic-custom-objects",
     "description": "This plugin adds custom objects feature.",
     "type": "mautic-plugin",
+    "version": "1.0",
     "config": {
         "process-timeout": 2000
     },
     "keywords": [
         "custom",
+        "objects",
         "mautic",
         "plugin"
     ],
+    "extra": {
+        "install-directory-name": "CustomObjectsBundle"
+    },
     "license": "GPL-3.0-or-later",
     "authors": [
         {
@@ -24,8 +29,12 @@
         "wiki": "https://github.com/acquia/mc-cs-plugin-custom-objects/wiki"
     },
     "require": {
-        "php": ">=7.3 <7.5",
-        "ext-mbstring": "*"
+        "php": ">=7.3",
+        "ext-mbstring": "*",
+        "mautic/core-lib": "^4.0"
+    },
+    "require-dev": {
+        "theofidry/alice-data-fixtures": "^1.1",
     },
     "minimum-stability": "dev",
     "scripts": {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I'm testing composer install with this branch. It contains:
- https://github.com/acquia/mc-cs-plugin-custom-objects/pull/256
- https://github.com/acquia/mc-cs-plugin-custom-objects/pull/250
- https://github.com/acquia/mc-cs-plugin-custom-objects/pull/259
- https://github.com/acquia/mc-cs-plugin-custom-objects/pull/266

Those PRs ⬆️  should be merged before this one.

#### Steps to test this PR:

I tried to install this branch into may local Mautic community instance by adding this into the `required` section:
```json
    "acquia/mc-cs-plugin-custom-objects": "4.x-dev"
```
and this into `repositories` section:
```json
{
      "type": "vcs",
      "url": "https://github.com/acquia/mc-cs-plugin-custom-objects.git"
}
```
But I wasn't able to get it installed even with special GH token generated. Acquia has some additional security that is blocking it it seems.

I created a branch that contains all PRs needed for this and the composer change:

https://github.com/mautic/mautic/compare/4.x...escopecz:co-all?expand=1

Then these commands will install the plugin:
`composer install`
`bin/console mautic:plugins:reload`