### PR TITLE
Fixing "PHP Notice - Trying to access array offset on value of type null"

### DIFF
--- a/Form/Type/CampaignConditionFieldValueType.php
+++ b/Form/Type/CampaignConditionFieldValueType.php
@@ -75,7 +75,7 @@ class CampaignConditionFieldValueType extends AbstractType
             ]
         );
 
-        if (isset($options['data']) && isset($options['data']['field']) && isset($fields[$options['data']['field']])) {
+        if (isset($options['data']['field']) && isset($fields[$options['data']['field']])) {
             $selectedField = $fields[$options['data']['field']];
         } else {
             $selectedField = array_values($fields)[0];

--- a/Form/Type/CampaignConditionFieldValueType.php
+++ b/Form/Type/CampaignConditionFieldValueType.php
@@ -75,7 +75,7 @@ class CampaignConditionFieldValueType extends AbstractType
             ]
         );
 
-        if (isset($fields[$options['data']['field']])) {
+        if (isset($options['data']) && isset($options['data']['field']) && isset($fields[$options['data']['field']])) {
             $selectedField = $fields[$options['data']['field']];
         } else {
             $selectedField = array_values($fields)[0];

--- a/Tests/Functional/EventListener/CampaignConditionTest.php
+++ b/Tests/Functional/EventListener/CampaignConditionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\EventListener;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
+use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\CustomObjectsTrait;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+class CampaignConditionTest extends MauticMysqlTestCase
+{
+    use CustomObjectsTrait;
+
+    public function testConditionForm(): void
+    {
+        $customObject = $this->createCustomObjectWithAllFields(self::$container, 'Campaign test object');
+        $crawler      = $this->client->request(
+            Request::METHOD_GET,
+            's/campaigns/events/new',
+            [
+                'campaignId'      => 'mautic_041b2a401f680fb0b644654af5ba0892f31f0697',
+                'type'            => "custom_item.{$customObject->getId()}.fieldvalue",
+                'eventType'       => 'condition',
+                'anchor'          => 'leadsource',
+                'anchorEventType' => 'source',
+            ],
+            [],
+            $this->createAjaxHeaders()
+        );
+
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+
+        $html = json_decode($this->client->getResponse()->getContent(), true)['newContent'];
+
+        $crawler->addHtmlContent($html);
+        
+        $textField = $customObject->getCustomFields()->filter(
+            fn (CustomField $customField) => 'text' === $customField->getTypeObject()->getKey()
+        )->first();
+        
+        $saveButton = $crawler->selectButton('campaignevent[buttons][save]');
+        $form       = $saveButton->form();
+        $form['campaignevent[properties][value]']->setValue('unicorn');
+        $form['campaignevent[properties][operator]']->setValue('=');
+        $form['campaignevent[properties][field]']->setValue($textField->getId());
+
+        $this->client->request($form->getMethod(), $form->getUri(), $form->getPhpValues(), $form->getPhpFiles(), $this->createAjaxHeaders());
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $clientResponse = $this->client->getResponse();
+        $body           = json_decode($clientResponse->getContent(), true);
+
+        Assert::assertSame(1, $body['success']);
+        Assert::assertEquals($textField->getId(), $body['event']['properties']['properties']['field']);
+        Assert::assertSame('=', $body['event']['properties']['properties']['operator']);
+        Assert::assertSame('unicorn', $body['event']['properties']['properties']['value']);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes one issue reported in https://github.com/mautic/mautic/pull/10883 and Acquia's https://backlog.acquia.com/browse/MAUT-4567

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This fixes a PHP notice when opening a custom object campaign condition. It is not visible in the production but blocks developers or testers on dev environment.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Create a custom object with a field
2. Create a new campaign
3. Select any source
4. Try to create a condition based on the custom object created in step 1.

If you are using dev environment (index_dev.php) then the form won't even load. If you are on production environment then the PHP notice will be logged into the logs.

Once you apply this PR then there will be no PHP notice.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->