### PR TITLE
Fixing the supported mautic/core-lib version and adding display name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "plugin"
     ],
     "extra": {
-        "install-directory-name": "CustomObjectsBundle"
+        "install-directory-name": "CustomObjectsBundle",
+        "display-name": "Custom Objects"
     },
     "license": "GPL-3.0-or-later",
     "authors": [
@@ -30,7 +31,7 @@
     "require": {
         "php": ">=7.4",
         "ext-mbstring": "*",
-        "mautic/core-lib": "^4.1"
+        "mautic/core-lib": "^4.3"
     },
     "require-dev": {
         "theofidry/alice-data-fixtures": "^1.1"


### PR DESCRIPTION
Mautic support this plugin only from version 4.3 onwards.
The display name is something we'll have to implement into the Mautic Marketplace as now it looks like this:
![Screen Shot 2022-05-24 at 15 42 58](https://user-images.githubusercontent.com/1235442/170050060-bbb651a3-2e31-46c1-87d7-9d4aa8fd4b83.png)


There is no need to test changes in this PR as they do not touch any PHP files.