### PR TITLE
MAUT-8066 - Fix CS fixer configuration for plugins

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -1134,7 +1134,7 @@ if (interface_exists('ApiPlatform\\Core\\Api\\IriConverterInterface')) {
             'custom_field.type.provider',
             'mautic.custom.model.item',
             'api_platform.iri_converter',
-            'doctrine.orm.entity_manager'
+            'doctrine.orm.entity_manager',
         ],
     ];
     $coParams['services']['other']['api_platform.custom_object.serializer.api_normalizer_json'] = [
@@ -1145,14 +1145,14 @@ if (interface_exists('ApiPlatform\\Core\\Api\\IriConverterInterface')) {
             'custom_field.type.provider',
             'mautic.custom.model.item',
             'api_platform.iri_converter',
-            'doctrine.orm.entity_manager'
+            'doctrine.orm.entity_manager',
         ],
     ];
     $coParams['services']['other']['api_platform.custom_object.custom_item.extension'] = [
-        'class' => \MauticPlugin\CustomObjectsBundle\Extension\CustomItemListeningExtension::class,
+        'class'     => \MauticPlugin\CustomObjectsBundle\Extension\CustomItemListeningExtension::class,
         'arguments' => [
             'mautic.helper.user',
-            'mautic.security'
+            'mautic.security',
         ],
         'tag' => 'api_platform.doctrine.orm.query_extension.collection',
     ];

--- a/Controller/CustomItem/LinkController.php
+++ b/Controller/CustomItem/LinkController.php
@@ -60,7 +60,7 @@ class LinkController extends JsonController
                 ['%itemId%' => $itemId, '%entityType%' => $entityType, '%entityId%' => $entityId],
                 FlashBag::LEVEL_ERROR
             );
-        } catch (ForbiddenException | NotFoundException | UnexpectedValueException $e) {
+        } catch (ForbiddenException|NotFoundException|UnexpectedValueException $e) {
             $this->flashBag->add($e->getMessage(), [], FlashBag::LEVEL_ERROR);
         }
 

--- a/Controller/CustomItem/LinkFormController.php
+++ b/Controller/CustomItem/LinkFormController.php
@@ -103,7 +103,7 @@ class LinkFormController extends AbstractFormController
                     ],
                 ]
             );
-        } catch (ForbiddenException | NotFoundException | UnexpectedValueException | NoRelationshipException $e) {
+        } catch (ForbiddenException|NotFoundException|UnexpectedValueException|NoRelationshipException $e) {
             $this->flashBag->add($e->getMessage(), [], FlashBag::LEVEL_ERROR);
         }
 
@@ -157,7 +157,7 @@ class LinkFormController extends AbstractFormController
 
                 return new JsonResponse($responseData);
             }
-        } catch (ForbiddenException | NoRelationshipException | NotFoundException $e) {
+        } catch (ForbiddenException|NoRelationshipException|NotFoundException $e) {
             $this->flashBag->add($e->getMessage(), [], FlashBag::LEVEL_ERROR);
         }
 

--- a/Controller/CustomItem/UnlinkController.php
+++ b/Controller/CustomItem/UnlinkController.php
@@ -64,7 +64,7 @@ class UnlinkController extends JsonController
                 'custom.item.unlinked',
                 ['%itemId%' => $customItem->getId(), '%itemName%' => $customItem->getName(), '%entityType%' => $entityType, '%entityId%' => $entityId]
             );
-        } catch (ForbiddenException | NotFoundException | UnexpectedValueException $e) {
+        } catch (ForbiddenException|NotFoundException|UnexpectedValueException $e) {
             $this->flashBag->add($e->getMessage(), [], FlashBag::LEVEL_ERROR);
         }
 

--- a/Entity/CustomObject.php
+++ b/Entity/CustomObject.php
@@ -42,12 +42,12 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
  */
 class CustomObject extends FormEntity implements UniqueEntityInterface
 {
-    const TABLE_NAME  = 'custom_object';
-    const TABLE_ALIAS = 'CustomObject';
+    public const TABLE_NAME  = 'custom_object';
+    public const TABLE_ALIAS = 'CustomObject';
 
     // Object type constants for $type field
-    const TYPE_MASTER       = 0;
-    const TYPE_RELATIONSHIP = 1;
+    public const TYPE_MASTER       = 0;
+    public const TYPE_RELATIONSHIP = 1;
 
     /**
      * @var int|null

--- a/EventListener/ImportSubscriber.php
+++ b/EventListener/ImportSubscriber.php
@@ -101,7 +101,7 @@ class ImportSubscriber implements EventSubscriberInterface
             $event->activeLink      = "#mautic_custom_object_$customObjectId";
             $event->setIndexRoute(CustomItemRouteProvider::ROUTE_LIST, ['objectId' => $customObjectId]);
             $event->stopPropagation();
-        } catch (NotFoundException | ForbiddenException $e) {
+        } catch (NotFoundException|ForbiddenException $e) {
         }
     }
 
@@ -133,7 +133,7 @@ class ImportSubscriber implements EventSubscriberInterface
                 $customObject->getNamePlural() => $fieldList,
                 'mautic.lead.special_fields'   => $specialFields,
             ];
-        } catch (NotFoundException | ForbiddenException $e) {
+        } catch (NotFoundException|ForbiddenException $e) {
         }
     }
 

--- a/EventListener/ReportSubscriber.php
+++ b/EventListener/ReportSubscriber.php
@@ -13,9 +13,7 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Helper\ReportHelper;
 use Mautic\ReportBundle\ReportEvents;
 use MauticPlugin\CustomObjectsBundle\Entity\CustomItem;
-use MauticPlugin\CustomObjectsBundle\Entity\CustomItemXrefCompany;
 use MauticPlugin\CustomObjectsBundle\Entity\CustomItemXrefContact;
-use MauticPlugin\CustomObjectsBundle\Entity\CustomItemXrefCustomItem;
 use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
 use MauticPlugin\CustomObjectsBundle\Report\ReportColumnsBuilder;
 use MauticPlugin\CustomObjectsBundle\Repository\CustomObjectRepository;
@@ -24,18 +22,18 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class ReportSubscriber implements EventSubscriberInterface
 {
-    const CUSTOM_OBJECTS_CONTEXT_GROUP    = 'custom.objects';
-    const CHILD_CUSTOM_OBJECT_NAME_PREFIX = '&nbsp;&nbsp;&nbsp;&nbsp;';
+    public const CUSTOM_OBJECTS_CONTEXT_GROUP    = 'custom.objects';
+    public const CHILD_CUSTOM_OBJECT_NAME_PREFIX = '&nbsp;&nbsp;&nbsp;&nbsp;';
 
-    const CUSTOM_ITEM_TABLE_ALIAS                  = 'ci';
-    const PARENT_CUSTOM_ITEM_TABLE_ALIAS           = 'pci';
-    const CUSTOM_ITEM_XREF_CUSTOM_ITEM_TABLE_ALIAS = 'cixci';
-    const CUSTOM_ITEM_XREF_CUSTOM_ITEM_TABLE_NAME  = 'custom_item_xref_custom_item';
-    const CUSTOM_ITEM_XREF_CONTACT_TABLE_ALIAS     = 'cil';
-    const CONTACTS_COMPANIES_XREF                  = 'cic';
-    const LEADS_TABLE_ALIAS                        = 'l';
-    const USERS_TABLE_ALIAS                        = 'u';
-    const COMPANIES_TABLE_ALIAS                    = 'comp';
+    public const CUSTOM_ITEM_TABLE_ALIAS                  = 'ci';
+    public const PARENT_CUSTOM_ITEM_TABLE_ALIAS           = 'pci';
+    public const CUSTOM_ITEM_XREF_CUSTOM_ITEM_TABLE_ALIAS = 'cixci';
+    public const CUSTOM_ITEM_XREF_CUSTOM_ITEM_TABLE_NAME  = 'custom_item_xref_custom_item';
+    public const CUSTOM_ITEM_XREF_CONTACT_TABLE_ALIAS     = 'cil';
+    public const CONTACTS_COMPANIES_XREF                  = 'cic';
+    public const LEADS_TABLE_ALIAS                        = 'l';
+    public const USERS_TABLE_ALIAS                        = 'u';
+    public const COMPANIES_TABLE_ALIAS                    = 'comp';
 
     /**
      * @var ArrayCollection

--- a/Migrations/Version_0_0_19.php
+++ b/Migrations/Version_0_0_19.php
@@ -11,7 +11,7 @@ use Mautic\IntegrationsBundle\Migration\AbstractMigration;
 
 class Version_0_0_19 extends AbstractMigration
 {
-    const FOREIGN_KEY_TO_DELETE = '/^FK_\d+594D0CC2$/';
+    public const FOREIGN_KEY_TO_DELETE = '/^FK_\d+594D0CC2$/';
 
     /** @var Schema */
     private $schema;

--- a/Report/ReportColumnsBuilder.php
+++ b/Report/ReportColumnsBuilder.php
@@ -11,7 +11,7 @@ use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
 
 class ReportColumnsBuilder
 {
-    const DEFAULT_COLUMN_TYPE = 'string';
+    public const DEFAULT_COLUMN_TYPE = 'string';
 
     /**
      * @var CustomObject

--- a/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
@@ -9,7 +9,6 @@ use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\Filter\BaseFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder as SegmentQueryBuilder;
 use Mautic\LeadBundle\Segment\RandomParameterName;
-use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 

--- a/Tests/Functional/ApiPlatform/AbstractApiPlatformFunctionalTest.php
+++ b/Tests/Functional/ApiPlatform/AbstractApiPlatformFunctionalTest.php
@@ -11,9 +11,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractApiPlatformFunctionalTest extends MauticMysqlTestCase
 {
-    /**
-     * @var array
-     */
     protected array $clientServer = [
         'PHP_AUTH_USER' => 'sales',
         'PHP_AUTH_PW'   => 'mautic',
@@ -24,7 +21,7 @@ abstract class AbstractApiPlatformFunctionalTest extends MauticMysqlTestCase
         if (!interface_exists('ApiPlatform\\Core\\Api\\IriConverterInterface')) {
             $this->markTestSkipped('ApiPlatform is not installed');
         }
-        
+
         parent::setUp();
     }
 

--- a/Tests/Functional/EventListener/CampaignConditionTest.php
+++ b/Tests/Functional/EventListener/CampaignConditionTest.php
@@ -36,11 +36,11 @@ class CampaignConditionTest extends MauticMysqlTestCase
         $html = json_decode($this->client->getResponse()->getContent(), true)['newContent'];
 
         $crawler->addHtmlContent($html);
-        
+
         $textField = $customObject->getCustomFields()->filter(
             fn (CustomField $customField) => 'text' === $customField->getTypeObject()->getKey()
         )->first();
-        
+
         $saveButton = $crawler->selectButton('campaignevent[buttons][save]');
         $form       = $saveButton->form();
         $form['campaignevent[properties][value]']->setValue('unicorn');

--- a/Tests/Functional/Exception/FixtureNotFoundException.php
+++ b/Tests/Functional/Exception/FixtureNotFoundException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace  MauticPlugin\CustomObjectsBundle\Tests\Functional\Exception;
+namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\Exception;
 
 use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
 

--- a/Tests/Unit/Form/Validator/CustomObjectTypeValuesValidatorTest.php
+++ b/Tests/Unit/Form/Validator/CustomObjectTypeValuesValidatorTest.php
@@ -6,7 +6,6 @@ namespace MauticPlugin\CustomObjectsBundle\Tests\Unit\Form\Validator;
 
 use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
 use MauticPlugin\CustomObjectsBundle\Form\Validator\Constraints\CustomObjectTypeValuesValidator;
-use PHPUnit\Framework\MockObject\Matcher\InvokedCount as InvokedCountMatcher;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;

--- a/Tests/Unit/Repository/CustomObjectRepositoryTest.php
+++ b/Tests/Unit/Repository/CustomObjectRepositoryTest.php
@@ -142,8 +142,7 @@ class CustomObjectRepositoryTest extends TestCase
 
     public function testGetFilterSegmentsMethod(): void
     {
-        $customObject = new class extends CustomObject
-        {
+        $customObject = new class() extends CustomObject {
             public function getId()
             {
                 return random_int(1, 100);

--- a/Tests/Unit/Serializer/ApiNormalizerTest.php
+++ b/Tests/Unit/Serializer/ApiNormalizerTest.php
@@ -3,7 +3,6 @@
 namespace MauticPlugin\CustomObjectsBundle\Tests\Unit\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use MauticPlugin\CustomObjectsBundle\CustomFieldType\CustomFieldTypeInterface;
 use MauticPlugin\CustomObjectsBundle\CustomFieldType\IntType;

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "unit": "../../bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=unit",
         "functional": "../../bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=functional",
         "coverage": "../../bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=all --coverage-text --coverage-html=Tests/Coverage",
-        "csfixer": "../../bin/php-cs-fixer fix . -v --dry-run --diff --using-cache=no",
-        "fixcs": "../../bin/php-cs-fixer fix . -v --using-cache=no"
+        "csfixer": "../../bin/php-cs-fixer fix . -v --dry-run --diff --using-cache=no --config=../../.php-cs-fixer.php",
+        "fixcs": "../../bin/php-cs-fixer fix . -v --using-cache=no --config=../../.php-cs-fixer.php"
     }
 }


### PR DESCRIPTION
Our plugin CS fixer configurations don't use the rules specified in .php-cs-fixer.php which leads in discrepancies between mc-cs and plugin CI runs. We need to specify the .php-cs-fixer.php via --config=../../.php-cs-fixer.php.

See https://backlog.acquia.com/browse/MAUT-8066