### PR TITLE
[BUGFIX] Add plugin-enabled check condition to CustomObjectPermissions…

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -998,6 +998,7 @@ $coParams = [
                 'class'     => ConfigProvider::class,
                 'arguments' => [
                     'mautic.helper.core_parameters',
+                    'database_connection',
                 ],
             ],
             'custom_field.type.provider' => [

--- a/Provider/ConfigProvider.php
+++ b/Provider/ConfigProvider.php
@@ -39,6 +39,11 @@ class ConfigProvider
      */
     public function pluginIsEnabled(): bool
     {
+        $pluginEnabled = (bool) $this->coreParametersHelper->get(self::CONFIG_PARAM_ENABLED, true);
+        if (!$pluginEnabled) {
+            return false;
+        }
+
         try {
             $pluginWasInstalledBefore = $this->connection
                 ->executeQuery('SELECT id FROM plugins WHERE bundle=:pluginName', ['pluginName' => self::CONFIG_PLUGIN_NAME])

--- a/Provider/ConfigProvider.php
+++ b/Provider/ConfigProvider.php
@@ -31,7 +31,7 @@ class ConfigProvider
     public function __construct(CoreParametersHelper $coreParametersHelper, Connection $connection)
     {
         $this->coreParametersHelper = $coreParametersHelper;
-        $this->connection = $connection;
+        $this->connection           = $connection;
     }
 
     /**

--- a/Provider/ConfigProvider.php
+++ b/Provider/ConfigProvider.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Provider;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
 
 class ConfigProvider
 {
     /**
      * @var string
      */
+    public const CONFIG_PLUGIN_NAME                                = 'CustomObjectsBundle';
     public const CONFIG_PARAM_ENABLED                              = 'custom_objects_enabled';
     public const CONFIG_PARAM_ITEM_VALUE_TO_CONTACT_RELATION_LIMIT = 'custom_object_item_value_to_contact_relation_limit';
 
@@ -19,9 +23,15 @@ class ConfigProvider
      */
     private $coreParametersHelper;
 
-    public function __construct(CoreParametersHelper $coreParametersHelper)
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(CoreParametersHelper $coreParametersHelper, Connection $connection)
     {
         $this->coreParametersHelper = $coreParametersHelper;
+        $this->connection = $connection;
     }
 
     /**
@@ -29,6 +39,16 @@ class ConfigProvider
      */
     public function pluginIsEnabled(): bool
     {
-        return (bool) $this->coreParametersHelper->get(self::CONFIG_PARAM_ENABLED, true);
+        try {
+            $pluginWasInstalledBefore = $this->connection
+                ->executeQuery('SELECT id FROM plugins WHERE bundle=:pluginName', ['pluginName' => self::CONFIG_PLUGIN_NAME])
+                ->rowCount();
+            $customObjectsTableExists = $this->connection
+                ->executeQuery('SHOW TABLES LIKE :tableName', ['tableName' => CustomObject::TABLE_NAME])
+                ->rowCount();
+            return $pluginWasInstalledBefore && $customObjectsTableExists;
+        } catch (Exception $e) {
+            return false;
+        }
     }
 }

--- a/Security/Permissions/CustomObjectPermissions.php
+++ b/Security/Permissions/CustomObjectPermissions.php
@@ -56,6 +56,10 @@ class CustomObjectPermissions extends AbstractPermissions
      */
     public function definePermissions(): void
     {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
         $this->addExtendedPermissions(['custom_fields', self::NAME]);
 
         $customObjects = $this->getCustomObjects();


### PR DESCRIPTION
To solve the issue #290, tag `1.0.0` (`94ff1e5`) was checked out. Because this resulted in a detached head, I had to create a branch which is `fix/issue-290`.