### PR TITLE
[BUGIX] Set correct wiki link in README.md (see #291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Once some of your contacts buy a Mautic T-shirt or hoodie you can link them with
 
 ## Documentation
 
-See [Wiki](wiki)
+See [Wiki](https://github.com/acquia/mc-cs-plugin-custom-objects/wiki)
 
 ## Tests
 


### PR DESCRIPTION
Just fixes the broken link to Github wiki (#291)