### PR TITLE
Fix import to objects

### DIFF
--- a/EventListener/ImportSubscriber.php
+++ b/EventListener/ImportSubscriber.php
@@ -228,7 +228,7 @@ class ImportSubscriber implements EventSubscriberInterface
         $requiredFields = $this->customFieldRepository->getRequiredCustomFieldsForCustomObject($customObjectId);
 
         $missingRequiredFields = $requiredFields->filter(function (CustomField $customField) use ($matchedFields) {
-            return !array_key_exists($customField->getAlias(), $matchedFields);
+            return !array_key_exists($customField->getId(), array_flip($matchedFields));
         })->map(function (CustomField $customField) {
             return "{$customField->getLabel()} ({$customField->getAlias()})";
         });


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | 
| Deprecations?                          | 
| BC breaks? (use the c.x branch)        | 
| Automated tests included?              | 
| Related user documentation PR URL      | not relevant
| Related developer documentation PR URL | not relevant
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
If you import items of a custom objects, you have error in UI if you have a mandatory field in the object even if mapped:
<img width="455" alt="Capture d’écran 2023-01-27 à 09 16 03" src="https://user-images.githubusercontent.com/14075239/215039465-3d57688c-7724-43e8-bf26-dce99fd75620.png">


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Setup a custom object
2. Set 1 custom object field as mandatory
3. Do an import AND map your mandatory field
4. See error thrown even if mapped.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->