### PR TITLE
Injecting objects and fields into forms and columns into reports

### DIFF
--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -6,6 +6,7 @@ namespace MauticPlugin\CustomObjectsBundle\EventListener;
 
 use Mautic\FormBundle\Crate\ObjectCrate;
 use Mautic\FormBundle\Event\FieldCollectEvent;
+use Mautic\FormBundle\Event\FieldDisplayEvent;
 use Mautic\FormBundle\Event\ObjectCollectEvent;
 use Mautic\FormBundle\FormEvents;
 use Mautic\FormBundle\Crate\FieldCrate;
@@ -13,8 +14,10 @@ use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
 use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
 use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
 use MauticPlugin\CustomObjectsBundle\Model\CustomObjectModel;
+use MauticPlugin\CustomObjectsBundle\Provider\CustomItemRouteProvider;
 use MauticPlugin\CustomObjectsBundle\Repository\CustomItemXrefContactRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class FormSubscriber implements EventSubscriberInterface
 {
@@ -22,21 +25,26 @@ class FormSubscriber implements EventSubscriberInterface
     private CustomItemModel $customItemModel;
     private CustomItemXrefContactRepository $customItemXrefContactRepository;
 
+    private RouterInterface $router;
+
     public function __construct(
         CustomObjectModel $customObjectModel,
         CustomItemModel $customItemModel,
-        CustomItemXrefContactRepository $customItemXrefContactRepository
+        CustomItemXrefContactRepository $customItemXrefContactRepository,
+        RouterInterface $router
     ) {
         $this->customObjectModel               = $customObjectModel;
         $this->customItemModel                 = $customItemModel;
         $this->customItemXrefContactRepository = $customItemXrefContactRepository;
+        $this->router                          = $router;
     }
 
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::ON_OBJECT_COLLECT => ['onObjectCollect', 0],
-            FormEvents::ON_FIELD_COLLECT  => ['onFieldCollect', 0],
+            FormEvents::ON_OBJECT_COLLECT      => ['onObjectCollect', 0],
+            FormEvents::ON_FIELD_COLLECT       => ['onFieldCollect', 0],
+            FormEvents::ON_FIELD_DISPLAY_EVENT => ['onFieldDisplay', 0],
         ];
     }
 
@@ -85,6 +93,41 @@ class FormSubscriber implements EventSubscriberInterface
             $list = $this->getCustomFieldValues($field, $items);
             $event->appendField(new FieldCrate($field->getAlias(), $field->getName(), $field->getType(), ['list' => $list]));
         }
+    }
+
+    public function onFieldDisplay(FieldDisplayEvent $event): void
+    {
+        try {
+            $object = $this->customObjectModel->fetchEntityByAlias($event->getObject());
+        } catch (NotFoundException $e) {
+            // Do nothing if the custom object doesn't exist.
+            return;
+        }
+
+        $ids   = explode(',', $event->getValue());
+        $value = '';
+
+        foreach ($ids as $id) {
+            $value .= strlen($value) > 0 ? ' ' : '';
+            $item = $this->customItemModel->getEntity($id);
+            if ($item) {
+                $viewParameters = [
+                    'objectId' => $object->getId(),
+                    'itemId' => $item->getId(),
+                ];
+                $route = $this->router->generate(CustomItemRouteProvider::ROUTE_VIEW, $viewParameters);
+                $value .= '<a href="' . $route . '" class="label label-success"> ' . $item->getName() . '</a>';
+            }
+        }
+        $event->setValue($value);
+//        $items = $this->customItemModel->fetchCustomItemsForObject($object);
+//        foreach ($ids as $id) {
+//            $value  .= strlen($value) > 0 ? ', ' : '';
+//            $item   = $this->customItemModel->getEntity($id);
+//            $value .= $item ? $item->getName() : '';
+//        }
+//
+//        $event->setValue($value);
     }
 
     /**

--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -108,7 +108,6 @@ class FormSubscriber implements EventSubscriberInterface
         $value = '';
 
         foreach ($ids as $id) {
-            $value .= strlen($value) > 0 ? ', ' : '';
             $item = $this->customItemModel->getEntity($id);
             if ($item) {
                 $viewParameters = [
@@ -116,7 +115,7 @@ class FormSubscriber implements EventSubscriberInterface
                     'itemId' => $item->getId(),
                 ];
                 $route = $this->router->generate(CustomItemRouteProvider::ROUTE_VIEW, $viewParameters);
-                $value .= '<a href="' . $route . '" class=""> ' . $item->getName() . '</a>';
+                $value .= '<a href="' . $route . '" class="label label-success mr-5"> '.$item->getId().'</a>';
             }
         }
         $event->setValue($value);

--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -108,7 +108,7 @@ class FormSubscriber implements EventSubscriberInterface
         $value = '';
 
         foreach ($ids as $id) {
-            $value .= strlen($value) > 0 ? ' ' : '';
+            $value .= strlen($value) > 0 ? ', ' : '';
             $item = $this->customItemModel->getEntity($id);
             if ($item) {
                 $viewParameters = [
@@ -116,18 +116,10 @@ class FormSubscriber implements EventSubscriberInterface
                     'itemId' => $item->getId(),
                 ];
                 $route = $this->router->generate(CustomItemRouteProvider::ROUTE_VIEW, $viewParameters);
-                $value .= '<a href="' . $route . '" class="label label-success"> ' . $item->getName() . '</a>';
+                $value .= '<a href="' . $route . '" class=""> ' . $item->getName() . '</a>';
             }
         }
         $event->setValue($value);
-//        $items = $this->customItemModel->fetchCustomItemsForObject($object);
-//        foreach ($ids as $id) {
-//            $value  .= strlen($value) > 0 ? ', ' : '';
-//            $item   = $this->customItemModel->getEntity($id);
-//            $value .= $item ? $item->getName() : '';
-//        }
-//
-//        $event->setValue($value);
     }
 
     /**

--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -52,7 +52,15 @@ class FormSubscriber implements EventSubscriberInterface
 
         $items = $this->customItemModel->fetchCustomItemsForObject($object);
 
-        foreach ($object->getCustomFields() as $field) {
+        if (count($items) > 0) {
+            foreach ($items as $item) {
+                $list[$item->getId()] = $item->getName();
+            }
+
+            $event->appendField(new FieldCrate($object->getAlias(), 'Name', 'text', ['list' => $list ?? []]));
+        }
+
+        foreach ($object->getCustomFields()->getValues() as $field) {
             $list = $this->getCustomFieldValues($field, $items);
             $event->appendField(new FieldCrate($field->getAlias(), $field->getName(), $field->getType(), ['list' => $list]));
         }

--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -51,10 +51,9 @@ class FormSubscriber implements EventSubscriberInterface
         }
 
         $items = $this->customItemModel->fetchCustomItemsForObject($object);
-
         if (count($items) > 0) {
             foreach ($items as $item) {
-                $list[$item->getName()] = $item->getName();
+                $list[$item->getId()] = $item->getName();
             }
 
             $event->appendField(new FieldCrate($object->getAlias(), 'Name', 'text', ['list' => $list ?? []]));
@@ -81,7 +80,7 @@ class FormSubscriber implements EventSubscriberInterface
 
                 foreach ($itemCustomFieldsValues as $customFieldValue) {
                     if ($field->getAlias() === $customFieldValue->getCustomField()->getAlias()) {
-                        $list[$item->getName()] = $customFieldValue->getValue();
+                        $list[$item->getId()] = $customFieldValue->getValue();
                     }
                 }
             }

--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -54,7 +54,7 @@ class FormSubscriber implements EventSubscriberInterface
 
         if (count($items) > 0) {
             foreach ($items as $item) {
-                $list[$item->getId()] = $item->getName();
+                $list[$item->getName()] = $item->getName();
             }
 
             $event->appendField(new FieldCrate($object->getAlias(), 'Name', 'text', ['list' => $list ?? []]));

--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\EventListener;
+
+use Mautic\FormBundle\Crate\ObjectCrate;
+use Mautic\FormBundle\Event\FieldCollectEvent;
+use Mautic\FormBundle\Event\ObjectCollectEvent;
+use Mautic\FormBundle\FormEvents;
+use Mautic\FormBundle\Crate\FieldCrate;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
+use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
+use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
+use MauticPlugin\CustomObjectsBundle\Model\CustomObjectModel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class FormSubscriber implements EventSubscriberInterface
+{
+    private CustomObjectModel $customObjectModel;
+    private CustomItemModel $customItemModel;
+
+    public function __construct(CustomObjectModel $customObjectModel, CustomItemModel $customItemModel)
+    {
+        $this->customObjectModel = $customObjectModel;
+        $this->customItemModel   = $customItemModel;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            FormEvents::ON_OBJECT_COLLECT => ['onObjectCollect', 0],
+            FormEvents::ON_FIELD_COLLECT  => ['onFieldCollect', 0],
+        ];
+    }
+
+    public function onObjectCollect(ObjectCollectEvent $event): void
+    {
+        foreach ($this->customObjectModel->fetchEntities() as $entity) {
+            $event->appendObject(new ObjectCrate($entity->getAlias(), $entity->getName()));
+        }
+    }
+
+    public function onFieldCollect(FieldCollectEvent $event): void
+    {
+        try {
+            $object = $this->customObjectModel->fetchEntityByAlias($event->getObject());
+        } catch (NotFoundException $e) {
+            // Do nothing if the custom object doesn't exist.
+            return;
+        }
+
+        $items = $this->customItemModel->fetchCustomItemsForObject($object);
+
+        foreach ($object->getCustomFields() as $field) {
+            $list = $this->getCustomFieldValues($field, $items);
+            $event->appendField(new FieldCrate($field->getAlias(), $field->getName(), $field->getType(), ['list' => $list]));
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getCustomFieldValues(CustomField $field, array $items): array
+    {
+        $list = [];
+
+        array_walk(
+            $items,
+            function ($item) use ($field, &$list) {
+                $itemWithCustomFieldValues = $this->customItemModel->populateCustomFields($item);
+                $itemCustomFieldsValues    = $itemWithCustomFieldValues->getCustomFieldValues();
+
+                foreach ($itemCustomFieldsValues as $customFieldValue) {
+                    if ($field->getAlias() === $customFieldValue->getCustomField()->getAlias()) {
+                        $list[$item->getName()] = $customFieldValue->getValue();
+                    }
+                }
+            }
+        );
+
+        return $list ?? [];
+    }
+}

--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -6,7 +6,6 @@ namespace MauticPlugin\CustomObjectsBundle\EventListener;
 
 use Mautic\FormBundle\Crate\ObjectCrate;
 use Mautic\FormBundle\Event\FieldCollectEvent;
-use Mautic\FormBundle\Event\FieldDisplayEvent;
 use Mautic\FormBundle\Event\ObjectCollectEvent;
 use Mautic\FormBundle\FormEvents;
 use Mautic\FormBundle\Crate\FieldCrate;
@@ -14,29 +13,19 @@ use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
 use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
 use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
 use MauticPlugin\CustomObjectsBundle\Model\CustomObjectModel;
-use MauticPlugin\CustomObjectsBundle\Provider\CustomItemRouteProvider;
-use MauticPlugin\CustomObjectsBundle\Repository\CustomItemXrefContactRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 class FormSubscriber implements EventSubscriberInterface
 {
     private CustomObjectModel $customObjectModel;
     private CustomItemModel $customItemModel;
-    private CustomItemXrefContactRepository $customItemXrefContactRepository;
-
-    private RouterInterface $router;
 
     public function __construct(
         CustomObjectModel $customObjectModel,
-        CustomItemModel $customItemModel,
-        CustomItemXrefContactRepository $customItemXrefContactRepository,
-        RouterInterface $router
+        CustomItemModel $customItemModel
     ) {
         $this->customObjectModel               = $customObjectModel;
         $this->customItemModel                 = $customItemModel;
-        $this->customItemXrefContactRepository = $customItemXrefContactRepository;
-        $this->router                          = $router;
     }
 
     public static function getSubscribedEvents(): array
@@ -44,7 +33,6 @@ class FormSubscriber implements EventSubscriberInterface
         return [
             FormEvents::ON_OBJECT_COLLECT      => ['onObjectCollect', 0],
             FormEvents::ON_FIELD_COLLECT       => ['onFieldCollect', 0],
-            FormEvents::ON_FIELD_DISPLAY_EVENT => ['onFieldDisplay', 0],
         ];
     }
 
@@ -66,21 +54,6 @@ class FormSubscriber implements EventSubscriberInterface
 
         $items = $this->customItemModel->fetchCustomItemsForObject($object);
 
-        if ($event->isAssigned()) {
-            $contactId = $event->getLead()?->getId();
-
-            $items = array_filter(
-                $items,
-                function ($item) use ($contactId) {
-                    $ids = $this->customItemXrefContactRepository->getContactIdsLinkedToCustomItem((int)$item->getId(), 200, 0);
-                    $ids = array_column($ids, 'contact_id');
-                    return in_array($contactId, $ids);
-                }
-            );
-
-            $event->removeFields();
-        }
-
         if (count($items) > 0) {
             foreach ($items as $item) {
                 $list[$item->getId()] = $item->getName();
@@ -93,32 +66,6 @@ class FormSubscriber implements EventSubscriberInterface
             $list = $this->getCustomFieldValues($field, $items);
             $event->appendField(new FieldCrate($field->getAlias(), $field->getName(), $field->getType(), ['list' => $list]));
         }
-    }
-
-    public function onFieldDisplay(FieldDisplayEvent $event): void
-    {
-        try {
-            $object = $this->customObjectModel->fetchEntityByAlias($event->getObject());
-        } catch (NotFoundException $e) {
-            // Do nothing if the custom object doesn't exist.
-            return;
-        }
-
-        $ids   = explode(',', $event->getValue());
-        $value = '';
-
-        foreach ($ids as $id) {
-            $item = $this->customItemModel->getEntity($id);
-            if ($item) {
-                $viewParameters = [
-                    'objectId' => $object->getId(),
-                    'itemId' => $item->getId(),
-                ];
-                $route = $this->router->generate(CustomItemRouteProvider::ROUTE_VIEW, $viewParameters);
-                $value .= '<a href="' . $route . '" class="label label-success mr-5"> '.$item->getId().'</a>';
-            }
-        }
-        $event->setValue($value);
     }
 
     /**

--- a/EventListener/ReportSubscriber.php
+++ b/EventListener/ReportSubscriber.php
@@ -131,9 +131,9 @@ class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::ON_COLUMN_COLLECT  => ['onColumnCollect', 0],
-            ReportEvents::REPORT_ON_GENERATE => [
+            ReportEvents::REPORT_ON_BUILD           => ['onReportBuilder', 0],
+            ReportEvents::REPORT_ON_COLUMN_COLLECT  => ['onReportColumnCollect', 0],
+            ReportEvents::REPORT_ON_GENERATE        => [
                 ['onReportGenerate', 0],
                 ['onFormResultReportGenerate', -1],
             ],
@@ -232,7 +232,7 @@ class ReportSubscriber implements EventSubscriberInterface
         }
     }
 
-    public function onColumnCollect(ColumnCollectEvent $event): void
+    public function onReportColumnCollect(ColumnCollectEvent $event): void
     {
         $object = $event->getObject();
 

--- a/EventListener/ReportSubscriber.php
+++ b/EventListener/ReportSubscriber.php
@@ -445,7 +445,7 @@ class ReportSubscriber implements EventSubscriberInterface
             $colCustomItemObjectId = sprintf('`%s`.`custom_object_id`', $customItemTableAlias);
             $colCustomObjectId     = sprintf('%s', $customObject->getId());
 
-            $joinCondition         = $this->fieldModel->hasChoices($field)
+            $joinCondition         = $field->hasChoices()
                 ? "{$colMappedField} LIKE CONCAT('%', {$colCustomObjectName}, '%') AND {$colCustomItemObjectId} = {$colCustomObjectId}"
                 : "{$colMappedField} = {$colCustomObjectName} AND {$colCustomItemObjectId} = {$colCustomObjectId}";
             $queryBuilder->leftJoin($prefixFormResultTable, CustomItem::TABLE_NAME, $customItemTableAlias, $joinCondition);

--- a/EventListener/ReportSubscriber.php
+++ b/EventListener/ReportSubscriber.php
@@ -403,6 +403,7 @@ class ReportSubscriber implements EventSubscriberInterface
     {
         $contextFormResult     = 'form.results';
         $prefixFormResultTable = 'fr';
+        $joinCustomObjectField = 'custom_object';
 
         $context               = $event->getContext();
 
@@ -425,7 +426,8 @@ class ReportSubscriber implements EventSubscriberInterface
                 $joinCondition  = sprintf(
                     '`%s`.`%s` = `%s`.`name` AND `%s`.`custom_object_id` = %s',
                     $prefixFormResultTable,
-                    $column['fieldAlias'],
+//                    $column['fieldAlias'],
+                    $joinCustomObjectField,
                     $customItemTablePrefix,
                     $customItemTablePrefix,
                     $customObject->getId()

--- a/EventListener/ReportSubscriber.php
+++ b/EventListener/ReportSubscriber.php
@@ -445,14 +445,8 @@ class ReportSubscriber implements EventSubscriberInterface
             $colCustomItemObjectId = sprintf('`%s`.`custom_object_id`', $customItemTableAlias);
             $colCustomObjectId     = sprintf('%s', $customObject->getId());
 
-            // conditions for join custom objects listed in a form field with multiple selection
-            $condition1 = "{$colMappedField} LIKE {$colCustomObjectName}";
-            $condition2 = "{$colMappedField} LIKE CONCAT({$colCustomObjectName}, ', %')";
-            $condition3 = "{$colMappedField} LIKE CONCAT('% ', {$colCustomObjectName}, ',%')";
-            $condition4 = "{$colMappedField} LIKE CONCAT('% ', {$colCustomObjectName})";
-
             $joinCondition         = $field->hasChoices()
-                ? "({$condition1} OR {$condition2} OR {$condition3} OR {$condition4}) AND {$colCustomItemObjectId} = {$colCustomObjectId}"
+                ? "FIND_IN_SET({$colCustomObjectName}, REPLACE({$colMappedField}, ' ', '')) > 0 AND {$colCustomItemObjectId} = {$colCustomObjectId}"
                 : "{$colMappedField} = {$colCustomObjectName} AND {$colCustomItemObjectId} = {$colCustomObjectId}";
             $queryBuilder->leftJoin($prefixFormResultTable, CustomItem::TABLE_NAME, $customItemTableAlias, $joinCondition);
 

--- a/EventListener/ReportSubscriber.php
+++ b/EventListener/ReportSubscriber.php
@@ -260,7 +260,7 @@ class ReportSubscriber implements EventSubscriberInterface
     {
         $companyColumns = $this->companyReportData->getCompanyData();
         // We don't need this column because we fetch company/lead relationships via custom objects
-        unset($companyColumns['companies_lead.is_primary']);
+        unset($companyColumns['companies_lead.is_primary'], $companyColumns['companies_lead.date_added']);
 
         return $companyColumns;
     }
@@ -403,7 +403,6 @@ class ReportSubscriber implements EventSubscriberInterface
     {
         $contextFormResult     = 'form.results';
         $prefixFormResultTable = 'fr';
-        $joinCustomObjectField = 'custom_object';
 
         $context               = $event->getContext();
 
@@ -426,8 +425,7 @@ class ReportSubscriber implements EventSubscriberInterface
                 $joinCondition  = sprintf(
                     '`%s`.`%s` = `%s`.`name` AND `%s`.`custom_object_id` = %s',
                     $prefixFormResultTable,
-//                    $column['fieldAlias'],
-                    $joinCustomObjectField,
+                    $column['fieldAlias'],
                     $customItemTablePrefix,
                     $customItemTablePrefix,
                     $customObject->getId()

--- a/EventListener/ReportSubscriber.php
+++ b/EventListener/ReportSubscriber.php
@@ -445,8 +445,14 @@ class ReportSubscriber implements EventSubscriberInterface
             $colCustomItemObjectId = sprintf('`%s`.`custom_object_id`', $customItemTableAlias);
             $colCustomObjectId     = sprintf('%s', $customObject->getId());
 
+            // conditions for join custom objects listed in a form field with multiple selection
+            $condition1 = "{$colMappedField} LIKE {$colCustomObjectName}";
+            $condition2 = "{$colMappedField} LIKE CONCAT({$colCustomObjectName}, ', %')";
+            $condition3 = "{$colMappedField} LIKE CONCAT('% ', {$colCustomObjectName}, ',%')";
+            $condition4 = "{$colMappedField} LIKE CONCAT('% ', {$colCustomObjectName})";
+
             $joinCondition         = $field->hasChoices()
-                ? "{$colMappedField} LIKE CONCAT('%', {$colCustomObjectName}, '%') AND {$colCustomItemObjectId} = {$colCustomObjectId}"
+                ? "({$condition1} OR {$condition2} OR {$condition3} OR {$condition4}) AND {$colCustomItemObjectId} = {$colCustomObjectId}"
                 : "{$colMappedField} = {$colCustomObjectName} AND {$colCustomItemObjectId} = {$colCustomObjectId}";
             $queryBuilder->leftJoin($prefixFormResultTable, CustomItem::TABLE_NAME, $customItemTableAlias, $joinCondition);
 

--- a/EventListener/ReportSubscriber.php
+++ b/EventListener/ReportSubscriber.php
@@ -6,6 +6,7 @@ namespace MauticPlugin\CustomObjectsBundle\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Mautic\FormBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\CompanyReportData;
 use Mautic\LeadBundle\Report\FieldsBuilder;
 use Mautic\ReportBundle\Event\ColumnCollectEvent;
@@ -19,7 +20,7 @@ use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
 use MauticPlugin\CustomObjectsBundle\Report\ReportColumnsBuilder;
 use MauticPlugin\CustomObjectsBundle\Repository\CustomObjectRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ReportSubscriber implements EventSubscriberInterface
 {
@@ -66,13 +67,22 @@ class ReportSubscriber implements EventSubscriberInterface
      */
     private $translator;
 
-    public function __construct(CustomObjectRepository $customObjectRepository, FieldsBuilder $fieldsBuilder, CompanyReportData $companyReportData, ReportHelper $reportHelper, TranslatorInterface $translator)
-    {
+    private FieldModel $fieldModel;
+
+    public function __construct(
+        CustomObjectRepository $customObjectRepository,
+        FieldsBuilder $fieldsBuilder,
+        CompanyReportData $companyReportData,
+        ReportHelper $reportHelper,
+        TranslatorInterface $translator,
+        FieldModel $fieldModel
+    ) {
         $this->customObjectRepository = $customObjectRepository;
         $this->fieldsBuilder          = $fieldsBuilder;
         $this->companyReportData      = $companyReportData;
         $this->reportHelper           = $reportHelper;
         $this->translator             = $translator;
+        $this->fieldModel             = $fieldModel;
     }
 
     private function getCustomObjects(): ArrayCollection
@@ -230,8 +240,8 @@ class ReportSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $customObject         = $this->customObjectRepository->findOneBy(['alias' => $object]);
-        $properties           = $event->getProperties();
+        $customObject        = $this->customObjectRepository->findOneBy(['alias' => $object]);
+        $properties          = $event->getProperties();
         $customItemTableAlias = static::CUSTOM_ITEM_TABLE_ALIAS.'_'.$customObject->getId();
         $customObjectColumns  = $this->getCustomObjectColumns($customObject, $customItemTableAlias.'.');
 
@@ -239,7 +249,8 @@ class ReportSubscriber implements EventSubscriberInterface
             $customObjectColumns,
             function (&$item, $index) use ($customObject, $properties) {
                 $item['idCustomObject'] = $customObject->getId();
-                $item                   = array_merge($item, $properties);            }
+                $item                   = array_merge($item, $properties);
+            }
         );
 
         $columns = array_merge(
@@ -403,42 +414,46 @@ class ReportSubscriber implements EventSubscriberInterface
     {
         $contextFormResult     = 'form.results';
         $prefixFormResultTable = 'fr';
-        $multipleChoice        = ['checkboxgrp', 'select'];
-
         $context               = $event->getContext();
 
         if (!str_starts_with($context, $contextFormResult)) {
             return;
         }
 
-        $columns = array_filter(
+        $addedCustomObjects = [];
+        $columns            = array_filter(
             $event->getOptions()['columns'],
-            fn ($elem) => isset($elem['idCustomObject']),
+            function ($elem) use (&$addedCustomObjects) {
+                // left one column for each custom object
+                $addToColumnList    = key_exists('idCustomObject', $elem) && !in_array($elem['idCustomObject'], $addedCustomObjects);
+                $addedCustomObjects[] = $elem['idCustomObject'] ?? '';
+
+                return $addToColumnList;
+            }
         );
 
         $queryBuilder = $event->getQueryBuilder();
 
-        $addedCustomObjects = [];
         foreach ($columns as $column) {
-            $customObject = $this->customObjectRepository->find($column['idCustomObject']);
-            if (!in_array($column['idCustomObject'], $addedCustomObjects)) {
-                $customItemTablePrefix = static::CUSTOM_ITEM_TABLE_ALIAS.'_'.$customObject->getId();
+            $customObject          = $this->customObjectRepository->find($column['idCustomObject']);
+            $field                 = $this->fieldModel->getEntity($column['idFormField']);
 
-                $colCustomObjectName = sprintf('`%s`.`name`', $customItemTablePrefix);
-                $colMappedField      = sprintf('`%s`.`%s`', $prefixFormResultTable, $column['fieldAlias']);
-                $colCustomItemObjectId = sprintf('`%s`.`custom_object_id`', $customItemTablePrefix);
-                $colCustomObjectId   = sprintf('%s', $customObject->getId());
+            $customItemTableAlias  = static::CUSTOM_ITEM_TABLE_ALIAS.'_'.$customObject->getId();
 
-                $joinCondition = in_array($column['fieldType'], $multipleChoice)
-                    ? "{$colMappedField} LIKE CONCAT('%', {$colCustomObjectName}, '%') AND {$colCustomItemObjectId} = {$colCustomObjectId}"
-                    : "{$colMappedField} = {$colCustomObjectName} AND {$colCustomItemObjectId} = {$colCustomObjectId}";
-                $queryBuilder->leftJoin($prefixFormResultTable, CustomItem::TABLE_NAME, $customItemTablePrefix, $joinCondition);
+            $colCustomObjectName   = sprintf('`%s`.`id`', $customItemTableAlias);
+            $colMappedField        = sprintf('`%s`.`%s`', $prefixFormResultTable, $field->getAlias());
+            $colCustomItemObjectId = sprintf('`%s`.`custom_object_id`', $customItemTableAlias);
+            $colCustomObjectId     = sprintf('%s', $customObject->getId());
 
-                $addedCustomObjects[] = $column['idCustomObject'];
-                $reportColumnsBuilder = new ReportColumnsBuilder($customObject);
-                $reportColumnsBuilder->setFilterColumnsCallback([$event, 'usesColumn']);
-                $reportColumnsBuilder->joinReportColumns($queryBuilder, $customItemTablePrefix);
-            }
+            $joinCondition         = $this->fieldModel->hasChoices($field)
+                ? "{$colMappedField} LIKE CONCAT('%', {$colCustomObjectName}, '%') AND {$colCustomItemObjectId} = {$colCustomObjectId}"
+                : "{$colMappedField} = {$colCustomObjectName} AND {$colCustomItemObjectId} = {$colCustomObjectId}";
+            $queryBuilder->leftJoin($prefixFormResultTable, CustomItem::TABLE_NAME, $customItemTableAlias, $joinCondition);
+
+            $addedCustomObjects[]  = $column['idCustomObject'];
+            $reportColumnsBuilder  = new ReportColumnsBuilder($customObject);
+            $reportColumnsBuilder->setFilterColumnsCallback([$event, 'usesColumn']);
+            $reportColumnsBuilder->joinReportColumns($queryBuilder, $customItemTableAlias);
         }
     }
 }

--- a/Model/CustomItemModel.php
+++ b/Model/CustomItemModel.php
@@ -7,6 +7,7 @@ namespace MauticPlugin\CustomObjectsBundle\Model;
 use Doctrine\DBAL\Query\QueryBuilder as DbalQueryBuilder;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Mautic\CoreBundle\Doctrine\Helper\FulltextKeyword;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
@@ -220,6 +221,40 @@ class CustomItemModel extends FormModel
         }
 
         return $this->populateCustomFields($customItem);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function fetchCustomItemsForObject(CustomObject $customObject): array
+    {
+        return $this->fetchEntities([
+            'filter' => [
+                'force' => [
+                    [
+                        'column' => CustomItem::TABLE_ALIAS.'.customObject',
+                        'value'  => $customObject->getId(),
+                        'expr'   => 'eq',
+                    ],
+                    [
+                        'column' => CustomItem::TABLE_ALIAS.'.isPublished',
+                        'value'  => true,
+                        'expr'   => 'eq',
+                    ],
+                ],
+            ],
+            'ignore_paginator' => true,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     *
+     * @return array<string, mixed>
+     */
+    public function fetchEntities(array $args = []): Paginator|array
+    {
+        return parent::getEntities($args);
     }
 
     /**

--- a/Tests/Unit/EventListener/ReportSubscriberTest.php
+++ b/Tests/Unit/EventListener/ReportSubscriberTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Mautic\FormBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\CompanyReportData;
 use Mautic\LeadBundle\Provider\FilterOperatorProviderInterface;
 use Mautic\LeadBundle\Report\FieldsBuilder;
@@ -25,6 +26,7 @@ use MauticPlugin\CustomObjectsBundle\Helper\CsvHelper;
 use MauticPlugin\CustomObjectsBundle\Repository\CustomObjectRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class ReportSubscriberTest extends TestCase
@@ -58,6 +60,11 @@ class ReportSubscriberTest extends TestCase
      * @var MockObject|TranslatorInterface
      */
     private $translatorInterface;
+
+    /**
+     * @var MockObject|FieldModel
+     */
+    private $fieldModelMock;
 
     /**
      * @var MockObject|FilterOperatorProviderInterface
@@ -96,9 +103,10 @@ class ReportSubscriberTest extends TestCase
         $this->customObjectRepository          = $this->createMock(CustomObjectRepository::class);
         $this->fieldsBuilder                   = $this->createMock(FieldsBuilder::class);
         $this->companyReportData               = $this->createMock(CompanyReportData::class);
-        $this->reportHelper                    = new ReportHelper();
-        $this->translatorInterface             = $this->createMock(TranslatorInterface::class);
-        $this->reportSubscriber                = new ReportSubscriber($this->customObjectRepository, $this->fieldsBuilder, $this->companyReportData, $this->reportHelper, $this->translatorInterface);
+        $this->reportHelper                    = new ReportHelper($this->createMock(EventDispatcherInterface::class));
+        $this->translatorInterface             = $this->createMock(\Symfony\Contracts\Translation\TranslatorInterface::class);
+        $this->leadFieldModelMock              = $this->createMock(FieldModel::class);
+        $this->reportSubscriber                = new ReportSubscriber($this->customObjectRepository, $this->fieldsBuilder, $this->companyReportData, $this->reportHelper, $this->translatorInterface, $this->fieldModelMock);
         $this->reportBuilderEvent              = $this->createMock(ReportBuilderEvent::class);
         $this->filterOperatorProviderInterface = $this->createMock(FilterOperatorProviderInterface::class);
         $this->csvHelper                       = $this->createMock(CsvHelper::class);

--- a/Tests/Unit/EventListener/ReportSubscriberTest.php
+++ b/Tests/Unit/EventListener/ReportSubscriberTest.php
@@ -106,7 +106,7 @@ class ReportSubscriberTest extends TestCase
         $this->reportHelper                    = new ReportHelper($this->createMock(EventDispatcherInterface::class));
         $this->translatorInterface             = $this->createMock(\Symfony\Contracts\Translation\TranslatorInterface::class);
         $this->leadFieldModelMock              = $this->createMock(FieldModel::class);
-        $this->reportSubscriber                = new ReportSubscriber($this->customObjectRepository, $this->fieldsBuilder, $this->companyReportData, $this->reportHelper, $this->translatorInterface, $this->fieldModelMock);
+        $this->reportSubscriber                = new ReportSubscriber($this->customObjectRepository, $this->fieldsBuilder, $this->companyReportData, $this->reportHelper, $this->translatorInterface, $this->leadFieldModelMock);
         $this->reportBuilderEvent              = $this->createMock(ReportBuilderEvent::class);
         $this->filterOperatorProviderInterface = $this->createMock(FilterOperatorProviderInterface::class);
         $this->csvHelper                       = $this->createMock(CsvHelper::class);
@@ -194,7 +194,7 @@ class ReportSubscriberTest extends TestCase
         $this->assertArrayHasKey(ReportEvents::REPORT_ON_BUILD, $events);
         $this->assertArrayHasKey(ReportEvents::REPORT_ON_GENERATE, $events);
         $this->assertContains('onReportBuilder', $events[ReportEvents::REPORT_ON_BUILD]);
-        $this->assertContains('onReportGenerate', $events[ReportEvents::REPORT_ON_GENERATE]);
+        $this->assertContains('onReportGenerate', $events[ReportEvents::REPORT_ON_GENERATE][0]);
     }
 
     public function testOnReportBuilderMethod(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->
:warning: This PR needs changes from PRs [#298](https://github.com/acquia/mc-cs-plugin-custom-objects/pull/298), [#308](https://github.com/acquia/mc-cs-plugin-custom-objects/pull/308), [#316](https://github.com/acquia/mc-cs-plugin-custom-objects/pull/316) so it can be tested after merging them.

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
This PR injects objects and fields into the form field mapping form and object columns into the form result report.
#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Setup a custom object. Use Mautic v5.
3. Create a custom object and add new items.
4. Create a form with fields mapped to the custom object. Add fields with text and select types.
    
![image](https://user-images.githubusercontent.com/96085911/216948469-d2d6b8b4-4b2b-40e0-8728-84b441365c28.png)

6. Ensure that mapping works well.
7. Submit the form.
8. Create a new report with the form result as a data source.
![image](https://user-images.githubusercontent.com/96085911/216949296-0b6e8f1a-5794-4cfd-b7a8-6ab5810ae98a.png)
10. Check if all object columns were added.
![image](https://user-images.githubusercontent.com/96085911/216949633-10ea7c9e-842f-43bd-8a70-517866c73f1d.png)
12. Select the fields.
13. Save rthe eport.
14. Check if the repotr is working correctly.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->