### PR TITLE
URL Decode custom-object tokens

### DIFF
--- a/Helper/TokenParser.php
+++ b/Helper/TokenParser.php
@@ -23,7 +23,7 @@ class TokenParser
 
         foreach ($matches[1] as $key => $tokenDataRaw) {
             $token = new Token($matches[0][$key]);
-            $parts = $this->getPartsDividedByPipe($tokenDataRaw);
+            $parts = $this->getPartsDividedByPipe(urldecode($tokenDataRaw));
 
             try {
                 $this->extractAliases($parts[0], $token);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
error on token in email based on a link field

#### Steps to test this PR:

1. Create url custom field on custom object
2. Create email
3. Add link from the custom field (on image `src` for instance) : `{custom-object=your_object:image_link | order=latest | limit=1}` ([see Acquia's doc if needed](https://github.com/acquia/mc-cs-plugin-custom-objects/wiki/Email-tokens)).
4. Send to contact
5. The image is not generated (src is empty)
<img width="677" alt="Capture d’écran 2023-02-16 à 08 57 41" src="https://user-images.githubusercontent.com/14075239/219302989-c56a3973-ae3c-43eb-a322-d1e7f6c0cef5.png">


**Apply PR, test again and all fixed 🚀 .**