### PR TITLE
add unique alias to custom objects query

### DIFF
--- a/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Segment\Query\Filter;
 
-use Doctrine\DBAL\DBALException;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\Filter\BaseFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder as SegmentQueryBuilder;
@@ -35,15 +34,13 @@ class CustomFieldFilterQueryBuilder extends BaseFilterQueryBuilder
         return 'mautic.lead.query.builder.custom_field.value';
     }
 
-    /**
-     * @throws DBALException
-     */
+    /** {@inheritDoc}  */
     public function applyQuery(SegmentQueryBuilder $queryBuilder, ContactSegmentFilter $filter): SegmentQueryBuilder
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $filterOperator  = $filter->getOperator();
 
-        $tableAlias = 'cfwq_'.(int) $filter->getField();
+        $tableAlias = sprintf('cfwq_%d_%s', (int) $filter->getField(), uniqid());
 
         $unionQueryContainer = $this->filterHelper->createValueQuery(
             $tableAlias,


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [X]

#### Description:

in case that filter contains two possible values for one filter only one value was used the alias for the union joins was not unique. this fixes it.

#### Steps to test this PR:

1. Create a report with custom field in dev environment so you can see the SQL
2. filter by same custom fields with two diffetent values like: text = aaa and text = bbb (multiple relations, so it makes sense)
3. check the SQL outputted in the report view.
