### PR TITLE
MAUT-10185 : Issue with custom object field value in segment filter

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -1146,6 +1146,7 @@ $coParams = [
                 'arguments' => [
                     'doctrine.orm.entity_manager',
                     'query_filter_factory',
+                    'mautic.lead.model.random_parameter_name',
                 ],
             ],
             'custom_object.helper.token_formatter' => [

--- a/Tests/Functional/Helper/QueryFilterHelperTest.php
+++ b/Tests/Functional/Helper/QueryFilterHelperTest.php
@@ -7,6 +7,7 @@ namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\Helper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterFactory;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\RandomParameterName;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterFactory;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
 use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
@@ -46,7 +47,8 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
                 $customFieldRepository,
                 new QueryFilterFactory\Calculator(),
                 1
-            )
+            ),
+            new RandomParameterName()
         );
 
         $fixturesDirectory = $this->getFixturesDirectory();
@@ -65,7 +67,7 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
     public function testGetCustomValueValueExpression(): void
     {
         $this->assertMatchWhere(
-            'test_value.value = :test_value_value',
+            'test_value.value = :par0',
             [
                 'glue'     => 'and',
                 'field'    => 'cmf_'.$this->getFixtureById('custom_field1')->getId(),
@@ -76,7 +78,7 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
         );
 
         $this->assertMatchWhere(
-            'test_value.value LIKE :test_value_value',
+            'test_value.value LIKE :par1',
             [
                 'glue'     => 'and',
                 'field'    => 'cmf_'.$this->getFixtureById('custom_field1')->getId(),
@@ -87,7 +89,7 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
         );
 
         $this->assertMatchWhere(
-            '(test_value.value <> :test_value_value) OR (test_value.value IS NULL)',
+            '(test_value.value <> :par2) OR (test_value.value IS NULL)',
             [
                 'glue'     => 'and',
                 'field'    => 'cmf_'.$this->getFixtureById('custom_field1')->getId(),
@@ -98,7 +100,7 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
         );
 
         $this->assertMatchWhere(
-            'test_value.value > :test_value_value',
+            'test_value.value > :par3',
             [
                 'glue'       => 'and',
                 'field'      => 'cmf_'.$this->getFixtureById('custom_object_product')->getId(),

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderTest.php
@@ -54,7 +54,8 @@ class CustomFieldFilterQueryBuilderTest extends MauticMysqlTestCase
                 $customFieldRepository,
                 new QueryFilterFactory\Calculator(),
                 1
-            )
+            ),
+            new RandomParameterName()
         );
         $queryBuilderService = new CustomFieldFilterQueryBuilder(
             new RandomParameterName(),

--- a/Tests/Functional/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
@@ -59,7 +59,8 @@ class CustomItemNameFilterQueryBuilderTest extends MauticMysqlTestCase
                 $customFieldRepository,
                 new QueryFilterFactory\Calculator(),
                 1
-            )
+            ),
+            new RandomParameterName()
         );
         $queryBuilderService = new CustomItemNameFilterQueryBuilder(
             new RandomParameterName(),

--- a/Tests/Unit/Helper/QueryFilterHelperTest.php
+++ b/Tests/Unit/Helper/QueryFilterHelperTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Mautic\LeadBundle\Segment\Query\Expression\ExpressionBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\RandomParameterName;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterFactory;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
 use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
@@ -49,7 +50,8 @@ class QueryFilterHelperTest extends TestCase
                 $this->createMock(CustomFieldRepository::class),
                 new QueryFilterFactory\Calculator(),
                 1
-            )
+            ),
+            new RandomParameterName()
         );
         $this->queryBuilder      = $this->createMock(QueryBuilder::class);
         $this->expressionBuilder = $this->createMock(ExpressionBuilder::class);
@@ -78,7 +80,7 @@ class QueryFilterHelperTest extends TestCase
         $this->queryBuilder
             ->expects($this->any())
             ->method('setParameter')
-            ->with('test_value_value', 'acquia', null);
+            ->with('par0', 'acquia', null);
 
         $this->queryFilterHelper
             ->addCustomObjectNameExpression($this->queryBuilder, 'test', 'eq', 'acquia');

--- a/Tests/Unit/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
+++ b/Tests/Unit/Segment/Query/Filter/CustomItemNameFilterQueryBuilderTest.php
@@ -68,7 +68,8 @@ class CustomItemNameFilterQueryBuilderTest extends TestCase
                 $this->createMock(CustomFieldRepository::class),
                 new QueryFilterFactory\Calculator(),
                 1
-            )
+            ),
+            new RandomParameterName()
         );
 
         $this->queryBuilder         = $this->createMock(QueryBuilder::class);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://backlog.acquia.com/browse/MAUT-10185 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
If we used same custom filed twice in Segment Filter it override the value for query parameter because query parameter name was generate same if one filed used multiple time in segment filter. 
https://github.com/acquia/mc-cs-plugin-custom-objects/blob/2865eb90a3c333ee9e5895698e15e83c283fa689/Helper/QueryFilterHelper.php#L164

**Implemented Solution:**
Now generating diff name for all query parameter using `RandomParameterName::class`
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
**Test 1:**
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom object with date fields.
3. Add 2 or more items in custom objects and attached it to contacts.
4. Create a segment with created date fields. (custom item values should be match with segment filter)
<img width="600" alt="image" src="https://github.com/acquia/mc-cs-plugin-custom-objects/assets/68939488/9ac3112b-35dd-45b4-b3ac-8ea98bbc9d75">

5. Save the segment and wait for the contacts to build.
6. Contacts which match the segment filter should be added in segment.

**Test 2:**
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom object with text fields.
3. create 2 or more items in custom objects and attached it to contacts.
4. Create a segment with created date fields (custom item values should be match with segment filter)
<img width="600" alt="image" src="https://github.com/acquia/mc-cs-plugin-custom-objects/assets/68939488/896ea25e-21a9-4832-8112-7dd7202d84b8">

5. Save the segment and wait for the contacts to build.
6. Contacts which match the segment filter should be added in segment.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->