### PR TITLE
MAUT-10983 : fix for custom item PATCH request is working same as PUT call

### DIFF
--- a/Entity/CustomItem.php
+++ b/Entity/CustomItem.php
@@ -452,8 +452,10 @@ class CustomItem extends FormEntity implements UniqueEntityInterface, UpsertInte
         }
 
         /**
-         * Using $_SERVER because we could have done it in CustomItemDataPersister but customItem
-         * entity has many public dependencies which could be a BC break.
+         * We could have done it in CustomItemDataPersister::persist() by
+         * injecting Symfony\Component\HttpFoundation\RequestStack and get request method.
+         * Since, CustomItem entity has multiple public methods which could lead to BC break.
+         * Hence, we are using $_SERVER here to get the request method type.
          */
         if ('PATCH' !== $_SERVER['REQUEST_METHOD']) {
             $this->setDefaultValuesForMissingFields();

--- a/Entity/CustomItem.php
+++ b/Entity/CustomItem.php
@@ -450,6 +450,10 @@ class CustomItem extends FormEntity implements UniqueEntityInterface, UpsertInte
                 $this->createNewCustomFieldValueByFieldId((int) $value['id'], $value['value']);
             }
         }
+
+        if ('PATCH' !== $_SERVER['REQUEST_METHOD']) {
+            $this->setDefaultValuesForMissingFields();
+        }
     }
 
     /**

--- a/Entity/CustomItem.php
+++ b/Entity/CustomItem.php
@@ -451,6 +451,10 @@ class CustomItem extends FormEntity implements UniqueEntityInterface, UpsertInte
             }
         }
 
+        /**
+         * Using $_SERVER because we could have done it in CustomItemDataPersister but customItem
+         * entity has many public dependencies which could be a BC break.
+         */
         if ('PATCH' !== $_SERVER['REQUEST_METHOD']) {
             $this->setDefaultValuesForMissingFields();
         }

--- a/Entity/CustomItem.php
+++ b/Entity/CustomItem.php
@@ -450,7 +450,6 @@ class CustomItem extends FormEntity implements UniqueEntityInterface, UpsertInte
                 $this->createNewCustomFieldValueByFieldId((int) $value['id'], $value['value']);
             }
         }
-        $this->setDefaultValuesForMissingFields();
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | No <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | - <!-- required for new features -->
| Related developer documentation PR URL | - <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-10983 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
When we send a PATCH call for a custom item then it updates the field for which we have send bug also removed the dat from other fields which are not send in request. This is the behaviour of PUT call not PATCH call. PATCH call should only update what we have send and keep other data intact.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create API credentials in ACS instance.
3. Create a custom object with few fields.
4. Create custom item of above object with all fields having some data.
5. Now login to API V2 URL `e.g. https://<instance-url>/api/v2`
6. Select PATCH call of API for Custom Item.
7. Send a payload with only one field for any Item which is having more than one custom fields.
8. When we 200 success call. Go to Application ACS. 
9. Open the item updated.
10. Verify that only one field value should be changed and another field values should not be changed.

Example Payload:
```
{
    "name": "A1",
    "customObject": "/api/v2/custom_objects/1",
    "fieldValues": [
        {
            "id": "/api/v2/custom_fields/2",
            "value": "Honda"
        }
    ],
    "additionalProp1": {}
}
```