### PR TITLE
Check API request by the controller name instead of real request path

### DIFF
--- a/EventListener/ApiSubscriber.php
+++ b/EventListener/ApiSubscriber.php
@@ -7,6 +7,7 @@ namespace MauticPlugin\CustomObjectsBundle\EventListener;
 use InvalidArgumentException;
 use Mautic\ApiBundle\ApiEvents;
 use Mautic\ApiBundle\Event\ApiEntityEvent;
+use Mautic\LeadBundle\Controller\Api\LeadApiController;
 use Mautic\LeadBundle\Entity\Lead;
 use MauticPlugin\CustomObjectsBundle\Entity\CustomItem;
 use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
@@ -119,7 +120,7 @@ class ApiSubscriber implements EventSubscriberInterface
             throw new InvalidArgumentException('Custom Object Plugin is disabled');
         }
 
-        if (1 !== preg_match('/^\/api\/contacts\/.*(new|edit)/', $request->getPathInfo())) {
+        if (1 !== preg_match('~^'.preg_quote(LeadApiController::class, '~').'::(new|edit)(Entity|Entities)Action$~i', $request->attributes->get('_controller'))) {
             throw new InvalidArgumentException('Not a API request we care about');
         }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-11469 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR changes the way of detecting `/contact/batch` endpoints, so it works for both real HTTP requests and requests created internally using Symfony's Request.

#### Steps to test this PR:

1. Create a new custom object with alias `products`. You do not need to any any fields. The default `name` field is enough.
2. Perform http request `POST /api/contacts/batch/new` with the following payload.
```json
[
    {
        "email": "mail@mailtest.mautic.com",
        "customObjects": {
            "data": [
                {
                    "alias": "products",
                    "data": [
                        {
                            "name": "Hello From API"
                        }
                    ]
                }
            ]
        }
    }
]
```
3. The newly created contact should have the given custom object/item attached on the contact's detail page.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->