### PR TITLE
NOT EQUAL operator not working with Custom Object Field filters

### DIFF
--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -90,7 +90,8 @@ class QueryFilterHelper
                 $segmentQueryBuilder,
                 $tableAlias,
                 $filter->getOperator(),
-                $valueParameter
+                $valueParameter,
+                true
             );
 
             $this->addOperatorExpression(
@@ -160,8 +161,20 @@ class QueryFilterHelper
         SegmentQueryBuilder $customQuery,
         string $tableAlias,
         string $operator,
-        string $valueParameter
+        string $valueParameter,
+        bool $alreadyNegated = false,
     ) {
+        if ($alreadyNegated) {
+            switch ($operator) {
+                case 'empty':
+                    $operator = 'notEmpty';
+                    break;
+                case 'neq':
+                    $operator = 'eq';
+                    break;
+            }
+        }
+
         switch ($operator) {
             case 'empty':
                 $expression = $customQuery->expr()->orX(

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -42,10 +42,11 @@ class QueryFilterHelper
 
     public function createValueQuery(
         string $alias,
-        ContactSegmentFilter $segmentFilter
+        ContactSegmentFilter $segmentFilter,
+        bool $filterAlreadyNegated = false
     ): UnionQueryContainer {
         $unionQueryContainer = $this->queryFilterFactory->createQuery($alias, $segmentFilter);
-        $this->addCustomFieldValueExpressionFromSegmentFilter($unionQueryContainer, $alias, $segmentFilter);
+        $this->addCustomFieldValueExpressionFromSegmentFilter($unionQueryContainer, $alias, $segmentFilter, $filterAlreadyNegated);
 
         return $unionQueryContainer;
     }
@@ -82,7 +83,8 @@ class QueryFilterHelper
     public function addCustomFieldValueExpressionFromSegmentFilter(
         UnionQueryContainer $unionQueryContainer,
         string $tableAlias,
-        ContactSegmentFilter $filter
+        ContactSegmentFilter $filter,
+        bool $filterAlreadyNegated = false
     ): void {
         foreach ($unionQueryContainer as $segmentQueryBuilder) {
             $valueParameter = $this->randomParameterNameService->generateRandomParameterName();
@@ -91,7 +93,7 @@ class QueryFilterHelper
                 $tableAlias,
                 $filter->getOperator(),
                 $valueParameter,
-                true
+                $filterAlreadyNegated
             );
 
             $this->addOperatorExpression(
@@ -162,7 +164,7 @@ class QueryFilterHelper
         string $tableAlias,
         string $operator,
         string $valueParameter,
-        bool $alreadyNegated = false,
+        bool $alreadyNegated = false
     ) {
         if ($alreadyNegated) {
             switch ($operator) {

--- a/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
@@ -45,10 +45,7 @@ class CustomFieldFilterQueryBuilder extends BaseFilterQueryBuilder
 
         $tableAlias = 'cfwq_'.(int) $filter->getField();
 
-        $unionQueryContainer = $this->filterHelper->createValueQuery(
-            $tableAlias,
-            $filter
-        );
+        $unionQueryContainer = $this->filterHelper->createValueQuery($tableAlias, $filter, true);
 
         foreach ($unionQueryContainer as $segmentQueryBuilder) {
             $segmentQueryBuilder->andWhere(

--- a/Tests/Functional/Segment/Query/Filter/CustomItemRelationQueryBuilderTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomItemRelationQueryBuilderTest.php
@@ -13,24 +13,13 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use MauticPlugin\CustomObjectsBundle\Provider\ConfigProvider;
 use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\FixtureObjectsTrait;
 
-class CustomItemRelationQueryBuilderTestCase extends MauticMysqlTestCase
+class CustomItemRelationQueryBuilderTest extends MauticMysqlTestCase
 {
     use FixtureObjectsTrait;
 
-    /**
-     * @var CoreParametersHelper
-     */
-    private $coreParametersHelper;
-
-    /**
-     * @var LeadListRepository
-     */
-    private $segmentRepository;
-
-    /**
-     * @var LeadRepository
-     */
-    private $contactRepository;
+    private CoreParametersHelper $coreParametersHelper;
+    private LeadListRepository $segmentRepository;
+    private LeadRepository $contactRepository;
 
     protected function setUp(): void
     {
@@ -176,8 +165,9 @@ class CustomItemRelationQueryBuilderTestCase extends MauticMysqlTestCase
             throw new InvalidArgumentException("No segment with alias '{$segmentAlias}' found");
         }
 
-        $count = $this->segmentRepository->getLeadCount([$segment->getId()]);
-        $count = (int) $count[$segment->getId()];
+        $count = $this->segmentRepository->getLeadCount($segment->getId());
+        $this->assertIsNumeric($count);
+        $count = (int) $count;
 
         $this->assertSame(
             $expectedLeadCount,
@@ -188,7 +178,7 @@ class CustomItemRelationQueryBuilderTestCase extends MauticMysqlTestCase
 
     private function assertContactIsInSegment(string $contactEmail, string $segmentAlias): void
     {
-        $contact = $this->contactRepository->findOneByEmail($contactEmail);
+        $contact = $this->contactRepository->findOneBy(['email' => $contactEmail]);
         /** @var LeadList[] $segments */
         $segments = $this->segmentRepository->getLeadLists($contact->getId());
 

--- a/Tests/Functional/Segment/Query/Filter/NegativeOperatorFilterQueryBuilderTest.php
+++ b/Tests/Functional/Segment/Query/Filter/NegativeOperatorFilterQueryBuilderTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\Segment\Query\Filter;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Command\UpdateLeadListsCommand;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomFieldValueText;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomItem;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
+use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
+use PHPUnit\Framework\Assert;
+
+class NegativeOperatorFilterQueryBuilderTest extends MauticMysqlTestCase
+{
+    private CustomItemModel $customItemModel;
+    private CustomObject $customObject;
+    private CustomField $customField;
+
+    protected function setUp(): void
+    {
+        $mergeFilterEnabled = ' with data set "Merge filter enabled"' === $this->getDataSetAsString(false);
+
+        $this->configParams['custom_object_merge_filter']                         = $mergeFilterEnabled;
+        $this->configParams['custom_object_item_value_to_contact_relation_limit'] = $mergeFilterEnabled ? 0 : 3;
+
+        parent::setUp();
+
+        $this->customItemModel = self::$container->get('mautic.custom.model.item');
+        $this->createCustomObjectWithCustomField();
+        $this->em->flush();
+    }
+
+    /**
+     * @return iterable<string, bool[]>
+     */
+    public function dataUseMergeFilter(): iterable
+    {
+        yield 'Merge filter enabled' => [true];
+        yield 'Merge filter disabled' => [false];
+    }
+
+    /**
+     * @dataProvider dataUseMergeFilter
+     */
+    public function testNotEqualsOperator(bool $mergeFilterEnabled): void
+    {
+        $this->createContactAndAttachCustomItem('abc', 'ABC');
+        $this->createContactAndAttachCustomItem('xyz', 'XYZ');
+        $this->createContactAndAttachCustomItem('empty', '');
+        $this->createContact('unlinked');
+
+        $segment = $this->createAndBuildSegment($this->createFilter('!=', 'abc'));
+
+        $members = $this->em->getRepository(ListLead::class)->findBy(['list' => $segment]);
+        Assert::assertCount($mergeFilterEnabled ? 2 : 3, $members);
+
+        $firstnames = $this->extractFirstnamesFromSegmentMembers($members);
+        Assert::assertNotContains('abc', $firstnames);
+        Assert::assertContains('xyz', $firstnames);
+        Assert::assertContains('empty', $firstnames);
+
+        if ($mergeFilterEnabled) {
+            Assert::assertNotContains('unlinked', $firstnames);
+        } else {
+            Assert::assertContains('unlinked', $firstnames);
+        }
+    }
+
+    /**
+     * @dataProvider dataUseMergeFilter
+     */
+    public function testEmptyOperator(bool $mergeFilterEnabled): void
+    {
+        $this->createContactAndAttachCustomItem('not empty', 'Not empty');
+        $this->createContactAndAttachCustomItem('empty', '');
+        $this->createContact('unlinked 1');
+        $this->createContact('unlinked 2');
+
+        $segment = $this->createAndBuildSegment($this->createFilter('empty', null));
+
+        $members = $this->em->getRepository(ListLead::class)->findBy(['list' => $segment]);
+        Assert::assertCount($mergeFilterEnabled ? 1 : 3, $members);
+
+        $firstnames = $this->extractFirstnamesFromSegmentMembers($members);
+        Assert::assertNotContains('not empty', $firstnames);
+        Assert::assertContains('empty', $firstnames);
+
+        if ($mergeFilterEnabled) {
+            Assert::assertNotContains('unlinked 1', $firstnames);
+            Assert::assertNotContains('unlinked 2', $firstnames);
+        } else {
+            Assert::assertContains('unlinked 1', $firstnames);
+            Assert::assertContains('unlinked 2', $firstnames);
+        }
+    }
+
+    private function createCustomItem(CustomObject $customObject, string $value, string $name): CustomItem
+    {
+        $customItem       = new CustomItem($customObject);
+        $customFieldValue = new CustomFieldValueText($this->customField, $customItem, $value);
+        $customItem->addCustomFieldValue($customFieldValue);
+        $customItem->setName($name);
+        $this->em->persist($customItem);
+        $this->em->persist($customFieldValue);
+
+        return $customItem;
+    }
+
+    private function createCustomObjectWithCustomField(): void
+    {
+        $this->customField = new CustomField();
+        $this->customField->setLabel('Field');
+        $this->customField->setAlias('field');
+        $this->customField->setType('text');
+        $this->em->persist($this->customField);
+
+        $this->customObject = new CustomObject();
+        $this->customObject->setAlias('Object');
+        $this->customObject->setNameSingular('Object');
+        $this->customObject->setNamePlural('Objects');
+        $this->customObject->addCustomField($this->customField);
+        $this->customField->setCustomObject($this->customObject);
+        $this->em->persist($this->customObject);
+    }
+
+    /**
+     * @param array<mixed> $filters
+     */
+    private function createAndBuildSegment(array $filters): LeadList
+    {
+        $segment = new LeadList();
+        $segment->setName('Segment A');
+        $segment->setAlias('segment-a');
+        $segment->setFilters($filters);
+        $this->em->persist($segment);
+        $this->em->flush($segment);
+        $this->em->clear();
+
+        $commandTester = $this->testSymfonyCommand(UpdateLeadListsCommand::NAME, ['-i' => $segment->getId()]);
+        Assert::assertSame(0, $commandTester->getStatusCode(), 'Update lead lists command was not successful');
+
+        return $segment;
+    }
+
+    private function createContact(string $firstname): Lead
+    {
+        $contact = new Lead();
+        $contact->setFirstname($firstname);
+        $this->em->persist($contact);
+
+        return $contact;
+    }
+
+    private function createContactAndAttachCustomItem(string $contactFirstname, string $customItemText): void
+    {
+        $contact = $this->createContact($contactFirstname);
+        $this->em->flush();
+
+        $customItem = $this->createCustomItem($this->customObject, $customItemText, $customItemText);
+        $this->customItemModel->linkEntity($customItem, 'contact', (int) $contact->getId());
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function createFilter(string $operator, ?string $value): array
+    {
+        $filters = [
+            [
+                'glue'       => 'and',
+                'field'      => 'cmf_'.$this->customField->getId(),
+                'object'     => 'custom_object',
+                'type'       => 'text',
+                'operator'   => $operator,
+                'properties' => [
+                    'filter' => $value,
+                ],
+            ],
+        ];
+
+        return $filters;
+    }
+
+    /**
+     * @param array<ListLead> $members
+     *
+     * @return array<string>
+     */
+    private function extractFirstnamesFromSegmentMembers(array $members): array
+    {
+        return array_map(fn (ListLead $segment) => $segment->getLead()->getFirstname(), $members);
+    }
+}

--- a/Tests/Functional/Segment/Query/Filter/NegativeOperatorFilterQueryBuilderTest.php
+++ b/Tests/Functional/Segment/Query/Filter/NegativeOperatorFilterQueryBuilderTest.php
@@ -197,3 +197,4 @@ class NegativeOperatorFilterQueryBuilderTest extends MauticMysqlTestCase
         return array_map(fn (ListLead $segment) => $segment->getLead()->getFirstname(), $members);
     }
 }
+


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [✅]
| New feature/enhancement? (use the a.x branch)      | [❌]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-11107 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR fixes "not equal" and "empty" operators when used with custom objects.

- `Not equal` operator:
    - Incorrectly returns linked **contacts matching the filter value** plus all the contacts that are not linked to any custom item.
    - Should return linked **contacts not matching the filter value** plus all the contacts that are not linked to any custom item.
- `Empty` operator:
    - Incorrectly return linked **contacts having non empty value** plus all the contacts that are not linked to any custom item.
    - Should return linked **contacts having empty value** plus all the contacts that are not linked to any custom item.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->

1. Create a custom object `Book` with a custom field `Publisher`.
2. Create 3 custom Items: BookABC, BookXYZ, BookEmpty using this custom object with `Publisher` field values as "ABC", "XYZ", and "" respectively. (Yes, the third one is an empty value) 
3. Create 3 contacts and link each contact to just one of the 3 custom items you created in the previous step.
4. Create 2 other contacts. Do not link these to any custom item.
5. Create a segment with `Not Equals` operator on `Publisher`. Provide the value "ABC" in the text box.
6. Save the segment and make sure the segment is built. 
8. The segment should contain the following contacts:
    - linked to BookXYZ and BookEmpty
    - any unlinked contacts
9. Create a segment with `Empty` operator on `Publisher`.
10. Save the segment and make sure the segment is built. 
11.  The segment should contain the following contacts:
    - linked to BookEmpty
    - any unlinked contacts


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->