### PR TITLE
Between operator for segments with numeric Custom Object fields

### DIFF
--- a/CustomFieldType/IntType.php
+++ b/CustomFieldType/IntType.php
@@ -47,7 +47,7 @@ class IntType extends AbstractCustomFieldType
     public function getOperators(): array
     {
         $allOperators     = parent::getOperators();
-        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty']);
+        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty', 'between', '!between']);
 
         return array_intersect_key($allOperators, $allowedOperators);
     }

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -168,7 +168,6 @@ class QueryFilterHelper
         string $operator,
         string $valueParameter,
         bool $alreadyNegated = false,
-        array $parameterValueArray = [],
         $filterParameterValue = null,
     ): CompositeExpression|string {
         if ($alreadyNegated) {

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -159,6 +159,8 @@ class QueryFilterHelper
      * Form the logical expression needed to limit the CustomValue's value for given operator.
      *
      * @param mixed $filterParameterValue
+     *
+     * @return CompositeExpression|string
      */
     private function getCustomValueValueExpression(
         SegmentQueryBuilder $customQuery,

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -158,7 +158,7 @@ class QueryFilterHelper
     /**
      * Form the logical expression needed to limit the CustomValue's value for given operator.
      *
-     * @param float|bool|array<mixed>|string|null $filterParameterValue
+     * @param mixed $filterParameterValue
      */
     private function getCustomValueValueExpression(
         SegmentQueryBuilder $customQuery,
@@ -167,6 +167,7 @@ class QueryFilterHelper
         string $valueParameter,
         bool $alreadyNegated = false,
         array $parameterValueArray = [],
+        $filterParameterValue = null,
     ): CompositeExpression|string {
         if ($alreadyNegated) {
             switch ($operator) {

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -168,8 +168,8 @@ class QueryFilterHelper
         string $operator,
         string $valueParameter,
         bool $alreadyNegated = false,
-        $filterParameterValue = null,
-    ): CompositeExpression|string {
+        $filterParameterValue = null
+    ) {
         if ($alreadyNegated) {
             switch ($operator) {
                 case 'empty':

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -158,7 +158,7 @@ class QueryFilterHelper
     /**
      * Form the logical expression needed to limit the CustomValue's value for given operator.
      *
-     * @param array<string> $parameterValueArray
+     * @param float|bool|array<mixed>|string|null $filterParameterValue
      */
     private function getCustomValueValueExpression(
         SegmentQueryBuilder $customQuery,
@@ -224,12 +224,15 @@ class QueryFilterHelper
                 break;
             case 'between':
             case 'notBetween':
+                if (is_array($filterParameterValue)) {
                     $expression = $customQuery->expr()->{$operator}(
                         $tableAlias.'_value.value',
-                        array_values($parameterValueArray)
+                        array_values($filterParameterValue)
                     );
                     break;
+                }
 
+                // no break
             default:
                 $expression     = $customQuery->expr()->{$operator}(
                     $tableAlias.'_value.value',

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -93,7 +93,8 @@ class QueryFilterHelper
                 $tableAlias,
                 $filter->getOperator(),
                 $valueParameter,
-                $filterAlreadyNegated
+                $filterAlreadyNegated,
+                $filter->getParameterValue()
             );
 
             $this->addOperatorExpression(
@@ -157,15 +158,16 @@ class QueryFilterHelper
     /**
      * Form the logical expression needed to limit the CustomValue's value for given operator.
      *
-     * @return CompositeExpression|string
+     * @param array<string> $parameterValueArray
      */
     private function getCustomValueValueExpression(
         SegmentQueryBuilder $customQuery,
         string $tableAlias,
         string $operator,
         string $valueParameter,
-        bool $alreadyNegated = false
-    ) {
+        bool $alreadyNegated = false,
+        array $parameterValueArray = [],
+    ): CompositeExpression|string {
         if ($alreadyNegated) {
             switch ($operator) {
                 case 'empty':
@@ -220,6 +222,14 @@ class QueryFilterHelper
                 );
 
                 break;
+            case 'between':
+            case 'notBetween':
+                    $expression = $customQuery->expr()->{$operator}(
+                        $tableAlias.'_value.value',
+                        array_values($parameterValueArray)
+                    );
+                    break;
+
             default:
                 $expression     = $customQuery->expr()->{$operator}(
                     $tableAlias.'_value.value',

--- a/Tests/Functional/Helper/QueryFilterHelperTest.php
+++ b/Tests/Functional/Helper/QueryFilterHelperTest.php
@@ -112,6 +112,23 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
                 ],
             ]
         );
+
+        $this->assertMatchWhere(
+            'test_value.value BETWEEN 0 AND 10',
+            [
+                'glue'       => 'and',
+                'field'      => 'cmf_'.$this->getFixtureById('custom_object_product')->getId(),
+                'object'     => 'custom_object',
+                'type'       => 'int',
+                'operator'   => 'between',
+                'properties' => [
+                    'filter' => [
+                        'number_from' => 0,
+                        'number_to'   => 10,
+                    ],
+                ],
+            ]
+        );
     }
 
     protected function assertMatchWhere(string $expectedWhere, array $filter): void

--- a/Tests/ProjectVersionTrait.php
+++ b/Tests/ProjectVersionTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests;
+
+trait ProjectVersionTrait
+{
+    private function isCloudProject(): bool
+    {
+        return str_starts_with(getenv('MAUTIC_PROJECT_VERSION'), 'cloud-');
+    }
+}

--- a/Tests/ProjectVersionTrait.php
+++ b/Tests/ProjectVersionTrait.php
@@ -8,6 +8,6 @@ trait ProjectVersionTrait
 {
     private function isCloudProject(): bool
     {
-        return str_starts_with(getenv('MAUTIC_PROJECT_VERSION'), 'cloud-');
+        return str_starts_with((string) getenv('MAUTIC_PROJECT_VERSION'), 'cloud-');
     }
 }

--- a/Tests/Unit/EventListener/SegmentFiltersChoicesGenerateSubscriberTest.php
+++ b/Tests/Unit/EventListener/SegmentFiltersChoicesGenerateSubscriberTest.php
@@ -214,8 +214,8 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
             'less than or equal'    => 'lte',
             'empty'                 => 'empty',
             'not empty'             => '!empty',
-            'between' => 'between',
-            'not between' => '!between',
+            'between'               => 'between',
+            'not between'           => '!between',
         ];
 
         $event = new LeadListFiltersChoicesEvent([], [], $this->translator);
@@ -274,8 +274,6 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
                 'not empty',
                 'like',
                 'not like',
-                'between',
-                'not between',
                 'regexp',
                 'not regexp',
                 'starts with',
@@ -291,6 +289,8 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
                 'not empty',
                 'like',
                 'not like',
+                'between',
+                'not between',
                 'regexp',
                 'not regexp',
                 'starts with',

--- a/Tests/Unit/EventListener/SegmentFiltersChoicesGenerateSubscriberTest.php
+++ b/Tests/Unit/EventListener/SegmentFiltersChoicesGenerateSubscriberTest.php
@@ -151,13 +151,11 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
                     'label'       => 'between',
                     'expr'        => 'between',
                     'negate_expr' => 'notBetween',
-                    'hide'        => true,
                 ],
             '!between' => [
                     'label'       => 'not between',
                     'expr'        => 'notBetween',
                     'negate_expr' => 'between',
-                    'hide'        => true,
                 ],
             'in' => [
                     'label'       => 'including',
@@ -216,6 +214,8 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
             'less than or equal'    => 'lte',
             'empty'                 => 'empty',
             'not empty'             => '!empty',
+            'between' => 'between',
+            'not between' => '!between',
         ];
 
         $event = new LeadListFiltersChoicesEvent([], [], $this->translator);
@@ -258,6 +258,8 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
                 ['mautic.lead.list.form.operator.isnotempty'],
                 ['mautic.lead.list.form.operator.islike'],
                 ['mautic.lead.list.form.operator.isnotlike'],
+                ['mautic.lead.list.form.operator.between'],
+                ['mautic.lead.list.form.operator.notbetween'],
                 ['mautic.lead.list.form.operator.regexp'],
                 ['mautic.lead.list.form.operator.notregexp'],
                 ['mautic.core.operator.starts.with'],
@@ -272,6 +274,8 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
                 'not empty',
                 'like',
                 'not like',
+                'between',
+                'not between',
                 'regexp',
                 'not regexp',
                 'starts with',

--- a/Tests/Unit/EventListener/SegmentFiltersChoicesGenerateSubscriberTest.php
+++ b/Tests/Unit/EventListener/SegmentFiltersChoicesGenerateSubscriberTest.php
@@ -208,7 +208,12 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
                 ],
         ];
 
-        $fieldOperators = [
+        $betweenOperators = $this->isCloudProject() ? [
+            'between'               => 'between',
+            'not between'           => '!between',
+        ] : [];
+
+        $fieldOperators = array_merge([
             'equals'                => '=',
             'not equal'             => '!=',
             'greater than'          => 'gt',
@@ -217,9 +222,7 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
             'less than or equal'    => 'lte',
             'empty'                 => 'empty',
             'not empty'             => '!empty',
-            'between'               => 'between',
-            'not between'           => '!between',
-        ];
+        ], $betweenOperators);
 
         $event = new LeadListFiltersChoicesEvent([], [], $this->translator);
 

--- a/Tests/Unit/EventListener/SegmentFiltersChoicesGenerateSubscriberTest.php
+++ b/Tests/Unit/EventListener/SegmentFiltersChoicesGenerateSubscriberTest.php
@@ -16,12 +16,15 @@ use MauticPlugin\CustomObjectsBundle\EventListener\SegmentFiltersChoicesGenerate
 use MauticPlugin\CustomObjectsBundle\Provider\ConfigProvider;
 use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
 use MauticPlugin\CustomObjectsBundle\Repository\CustomObjectRepository;
+use MauticPlugin\CustomObjectsBundle\Tests\ProjectVersionTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
 {
+    use ProjectVersionTrait;
+
     /**
      * @var CustomObjectRepository|MockObject
      */
@@ -233,70 +236,74 @@ class SegmentFiltersChoicesGenerateSubscriberTest extends TestCase
             ->with($criteria)
             ->willReturn(new ArrayCollection([$customObject]));
 
+        $translationsKeys = array_filter([
+            ['custom.item.name.label'],
+            ['mautic.lead.list.form.operator.equals'],
+            ['mautic.lead.list.form.operator.notequals'],
+            ['mautic.lead.list.form.operator.isempty'],
+            ['mautic.lead.list.form.operator.isnotempty'],
+            ['mautic.lead.list.form.operator.islike'],
+            ['mautic.lead.list.form.operator.isnotlike'],
+            ['mautic.lead.list.form.operator.regexp'],
+            ['mautic.lead.list.form.operator.notregexp'],
+            ['mautic.core.operator.starts.with'],
+            ['mautic.core.operator.ends.with'],
+            ['mautic.core.operator.contains'],
+            ['mautic.lead.list.form.operator.equals'],
+            ['mautic.lead.list.form.operator.notequals'],
+            ['mautic.lead.list.form.operator.greaterthan'],
+            ['mautic.lead.list.form.operator.greaterthanequals'],
+            ['mautic.lead.list.form.operator.lessthan'],
+            ['mautic.lead.list.form.operator.lessthanequals'],
+            ['mautic.lead.list.form.operator.isempty'],
+            ['mautic.lead.list.form.operator.isnotempty'],
+            ['mautic.lead.list.form.operator.islike'],
+            ['mautic.lead.list.form.operator.isnotlike'],
+            $this->isCloudProject() ? ['mautic.lead.list.form.operator.between'] : null,
+            $this->isCloudProject() ? ['mautic.lead.list.form.operator.notbetween'] : null,
+            ['mautic.lead.list.form.operator.regexp'],
+            ['mautic.lead.list.form.operator.notregexp'],
+            ['mautic.core.operator.starts.with'],
+            ['mautic.core.operator.ends.with'],
+            ['mautic.core.operator.contains'],
+        ]);
+
+        $translations = array_filter([
+            'Mobile',
+            'equals',
+            'not equal',
+            'empty',
+            'not empty',
+            'like',
+            'not like',
+            'regexp',
+            'not regexp',
+            'starts with',
+            'ends with',
+            'contains',
+            'equals',
+            'not equal',
+            'greater than',
+            'greater than or equal',
+            'less than',
+            'less than or equal',
+            'empty',
+            'not empty',
+            'like',
+            'not like',
+            $this->isCloudProject() ? 'between' : null,
+            $this->isCloudProject() ? 'not between' : null,
+            'regexp',
+            'not regexp',
+            'starts with',
+            'ends with',
+            'contains',
+        ]);
+
         $this->translator
             ->method('trans')
-            ->withConsecutive(
-                ['custom.item.name.label'],
-                ['mautic.lead.list.form.operator.equals'],
-                ['mautic.lead.list.form.operator.notequals'],
-                ['mautic.lead.list.form.operator.isempty'],
-                ['mautic.lead.list.form.operator.isnotempty'],
-                ['mautic.lead.list.form.operator.islike'],
-                ['mautic.lead.list.form.operator.isnotlike'],
-                ['mautic.lead.list.form.operator.regexp'],
-                ['mautic.lead.list.form.operator.notregexp'],
-                ['mautic.core.operator.starts.with'],
-                ['mautic.core.operator.ends.with'],
-                ['mautic.core.operator.contains'],
-                ['mautic.lead.list.form.operator.equals'],
-                ['mautic.lead.list.form.operator.notequals'],
-                ['mautic.lead.list.form.operator.greaterthan'],
-                ['mautic.lead.list.form.operator.greaterthanequals'],
-                ['mautic.lead.list.form.operator.lessthan'],
-                ['mautic.lead.list.form.operator.lessthanequals'],
-                ['mautic.lead.list.form.operator.isempty'],
-                ['mautic.lead.list.form.operator.isnotempty'],
-                ['mautic.lead.list.form.operator.islike'],
-                ['mautic.lead.list.form.operator.isnotlike'],
-                ['mautic.lead.list.form.operator.between'],
-                ['mautic.lead.list.form.operator.notbetween'],
-                ['mautic.lead.list.form.operator.regexp'],
-                ['mautic.lead.list.form.operator.notregexp'],
-                ['mautic.core.operator.starts.with'],
-                ['mautic.core.operator.ends.with'],
-                ['mautic.core.operator.contains']
-            )
-            ->willReturn(
-                'Mobile',
-                'equals',
-                'not equal',
-                'empty',
-                'not empty',
-                'like',
-                'not like',
-                'regexp',
-                'not regexp',
-                'starts with',
-                'ends with',
-                'contains',
-                'equals',
-                'not equal',
-                'greater than',
-                'greater than or equal',
-                'less than',
-                'less than or equal',
-                'empty',
-                'not empty',
-                'like',
-                'not like',
-                'between',
-                'not between',
-                'regexp',
-                'not regexp',
-                'starts with',
-                'ends with',
-                'contains'
-            );
+            ->withConsecutive(...$translationsKeys)
+            ->willReturn(...$translations);
 
         $this->filterOperatorProvider->expects($this->once())
             ->method('getAllOperators')


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ No]
| New feature/enhancement? (use the a.x branch)      | [ Yes]
| Deprecations?                          | [ NA]
| BC breaks? (use the c.x branch)        | [NA ]
| Automated tests included?              | [ Yes] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

This PR implements the between operator in segments for numeric fields.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a Custom Object People/Person and add a number field "Family Members".
3. Create 3 custom items from this object; 'A', 'B' and 'C' and assign them 3, 7 and 12 family members respectively.
4. Create 3 contacts 'A', 'B' and 'C' and link them to People 'A', 'B' and 'C' respectively.
5. Create a new segment "Family Members Between Segment" and add People:Family Members as filter field.
6. Choose "between" operator. Two input fields should appear. 
<img width="1440" alt="image" src="https://github.com/acquia/mc-cs/assets/45942361/797d4f93-51c2-45c6-8355-af1d7997e136">

7. Enter 5 and 10 in the "From" and "To" boxes respectively and save the segment.
8. Wait for the segment to build.
9. Verify that only contact B (the one with 7 family members) is a member of the segment.
10. Additionally try saving the segment leaving either of the two input fields blank, or entering non integer values. You should see an error message. 
<img width="1080" alt="image" src="https://github.com/acquia/mc-cs/assets/45942361/81a96cc9-b0d7-4fb9-bfae-d9345266060b">
11. Create another segment, "Family Members Not Between Segment", with same configurations as the previous one. Except this time choose "not between" operator.

12. Wait for the segment to build and verify that this time the contacts with 3 and 12 family members are members of the segment.


#### Other areas of Mautic that may be affected by the change: NA

