### PR TITLE
MAUT-11289 : Segments: New (not)between date filter

### DIFF
--- a/CustomFieldType/DateTimeType.php
+++ b/CustomFieldType/DateTimeType.php
@@ -76,7 +76,7 @@ class DateTimeType extends AbstractCustomFieldType
     public function getOperators(): array
     {
         $allOperators     = parent::getOperators();
-        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty']);
+        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty', 'between', '!between']);
 
         return array_intersect_key($allOperators, $allowedOperators);
     }

--- a/CustomFieldType/DateType.php
+++ b/CustomFieldType/DateType.php
@@ -76,7 +76,7 @@ class DateType extends AbstractCustomFieldType
     public function getOperators(): array
     {
         $allOperators     = parent::getOperators();
-        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty']);
+        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty', 'between', '!between']);
 
         return array_intersect_key($allOperators, $allowedOperators);
     }

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -217,10 +217,11 @@ class QueryFilterHelper
                         array_map(function (mixed $val) use ($customQuery): mixed {
                             return is_numeric($val) && intval($val) === $val ?
                                 $val : $customQuery->expr()->literal($val);
-                        }, $filterParameterValue)
+                        }, array_values($filterParameterValue))
                     );
+                    break;
                 }
-                break;
+                // no break
             default:
                 $expression     = $customQuery->expr()->{$operator}(
                     $tableAlias.'_value.value',

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -236,7 +236,6 @@ class QueryFilterHelper
                     );
                     break;
                 }
-                // no break
             default:
                 $expression     = $customQuery->expr()->{$operator}(
                     $tableAlias.'_value.value',

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -179,6 +179,10 @@ class QueryFilterHelper
                 case 'neq':
                     $operator = 'eq';
                     break;
+                case '!between':
+                case 'notBetween':
+                    $operator = 'between';
+                    break;
             }
         }
 

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -361,7 +361,7 @@ class QueryFilterHelper
             $cinAlias                   = 'cin_'.$segmentFilterFieldId;
             $cinAliasItem               = $cinAlias.'_item';
             $valueParameter             = $this->randomParameterNameService->generateRandomParameterName();
-
+            $segmentFilter              = $filter['filter'];
             if ($isCmoFilter && !in_array($cinAliasItem, $joinedAlias, true)) {
                 $this->joinMergeCustomItem($qb, $customItemXrefContactAlias, $cinAliasItem, $segmentFilterFieldId);
                 $joinedAlias[] = $cinAliasItem;
@@ -383,7 +383,7 @@ class QueryFilterHelper
                     $qb,
                     $cinAlias,
                     $alias,
-                    $segmentFilterFieldOperator,
+                    $segmentFilter,
                     $valueParameter
                 ),
                 $segmentFilterFieldOperator,
@@ -436,9 +436,10 @@ class QueryFilterHelper
         SegmentQueryBuilder $qb,
         string $cinAlias,
         string $alias,
-        string $segmentFilterFieldOperator,
+        ContactSegmentFilter $segmentFilter,
         string $valueParameter
     ) {
+        $segmentFilterFieldOperator = $segmentFilter->getOperator();
         if ($isCmoFilter) {
             $expression = $this->getCustomObjectNameExpression(
                 $qb,
@@ -451,7 +452,9 @@ class QueryFilterHelper
                 $qb,
                 $alias,
                 $segmentFilterFieldOperator,
-                $valueParameter
+                $valueParameter,
+                false,
+                $segmentFilter->getParameterValue()
             );
         }
 

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -236,6 +236,7 @@ class QueryFilterHelper
                     );
                     break;
                 }
+                // no break
             default:
                 $expression     = $customQuery->expr()->{$operator}(
                     $tableAlias.'_value.value',

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -354,14 +354,16 @@ class QueryFilterHelper
             $segmentFilterFieldType     = $filter['type'] ?: $this->queryFilterFactory
                 ->getCustomFieldTypeById($segmentFilterFieldId);
             $dataTable                  = $this->queryFilterFactory->getTableNameFromType($segmentFilterFieldType);
+            $segmentMergedFilter        = $filter['filter'];
             $segmentFilterFieldOperator = (string) $filter['operator'];
+
             $alias                      = $customItemXrefContactAlias.'_'.$segmentFilterFieldId.'_'.$filter['type'];
             $aliasValue                 = $alias.'_value';
             $isCmoFilter                = $filter['cmo_filter'] ?? false;
             $cinAlias                   = 'cin_'.$segmentFilterFieldId;
             $cinAliasItem               = $cinAlias.'_item';
             $valueParameter             = $this->randomParameterNameService->generateRandomParameterName();
-            $segmentFilter              = $filter['filter'];
+
             if ($isCmoFilter && !in_array($cinAliasItem, $joinedAlias, true)) {
                 $this->joinMergeCustomItem($qb, $customItemXrefContactAlias, $cinAliasItem, $segmentFilterFieldId);
                 $joinedAlias[] = $cinAliasItem;
@@ -383,7 +385,7 @@ class QueryFilterHelper
                     $qb,
                     $cinAlias,
                     $alias,
-                    $segmentFilter,
+                    $segmentMergedFilter,
                     $valueParameter
                 ),
                 $segmentFilterFieldOperator,
@@ -436,10 +438,10 @@ class QueryFilterHelper
         SegmentQueryBuilder $qb,
         string $cinAlias,
         string $alias,
-        ContactSegmentFilter $segmentFilter,
+        ContactSegmentFilter $filter,
         string $valueParameter
     ) {
-        $segmentFilterFieldOperator = $segmentFilter->getOperator();
+        $segmentFilterFieldOperator = $filter->getOperator();
         if ($isCmoFilter) {
             $expression = $this->getCustomObjectNameExpression(
                 $qb,
@@ -454,7 +456,7 @@ class QueryFilterHelper
                 $segmentFilterFieldOperator,
                 $valueParameter,
                 false,
-                $segmentFilter->getParameterValue()
+                $filter->getParameterValue()
             );
         }
 

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -207,7 +207,8 @@ class QueryFilterHelper
                     $customQuery->expr()->isNull($tableAlias.'_value.value'),
                     $customQuery->expr()->like($tableAlias.'_value.value', ":${valueParameter}")
                 );
-                // no break
+
+                break;
             case 'between':
             case 'notBetween':
                 if (is_array($filterParameterValue)) {
@@ -218,7 +219,6 @@ class QueryFilterHelper
                                 $val : $customQuery->expr()->literal($val);
                         }, $filterParameterValue)
                     );
-                    break;
                 }
                 break;
             default:

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -214,7 +214,8 @@ class QueryFilterHelper
                     $expression = $customQuery->expr()->{$operator}(
                         $tableAlias.'_value.value',
                         array_map(function (mixed $val) use ($customQuery): mixed {
-                            return is_numeric($val) && intval($val) === $val ? $val : $customQuery->expr()->literal($val);
+                            return is_numeric($val) && intval($val) === $val ?
+                                $val : $customQuery->expr()->literal($val);
                         }, $filterParameterValue)
                     );
                     break;

--- a/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
@@ -58,6 +58,8 @@ class CustomFieldFilterQueryBuilder extends BaseFilterQueryBuilder
             case 'neq':
             case 'notLike':
             case '!multiselect':
+            case '!between':
+            case 'notBetween':
                 $queryBuilder->addLogic(
                     $queryBuilder->expr()->notExists($unionQueryContainer->getSQL()),
                     $filter->getGlue()

--- a/Tests/Functional/Helper/QueryFilterHelperTest.php
+++ b/Tests/Functional/Helper/QueryFilterHelperTest.php
@@ -112,6 +112,23 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
                 ],
             ]
         );
+
+        $this->assertMatchWhere(
+            "test_value.value BETWEEN '2024-05-15 00:00:00' AND '2024-05-24 23:59:59'",
+            [
+                'glue'       => 'and',
+                'field'      => 'cmf_'.$this->getFixtureById('custom_object_product')->getId(),
+                'object'     => 'custom_object',
+                'type'       => 'datetime',
+                'operator'   => 'between',
+                'properties' => [
+                    'filter' => [
+                        'date_from' => 'May 15, 2024',
+                        'date_to'   => 'May 24, 2024',
+                    ],
+                ],
+            ]
+        );
     }
 
     protected function assertMatchWhere(string $expectedWhere, array $filter): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | No
| New feature/enhancement? (use the a.x branch)      | Yes
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-11289 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR adds new between and not between operators for the date fields and allows users to set 2 absolute dates like this:

<img width="1098" alt="image" src="https://github.com/acquia/mc-cs-plugin-custom-objects/assets/48244990/98262c07-5d13-4361-9f2c-807859f219c6">

The validation is also in place. This is how it looks like when one of the date ranges is empty:
<img width="1092" alt="image" src="https://github.com/acquia/mc-cs-plugin-custom-objects/assets/48244990/54e6d3d2-141c-4f95-ab0a-3d102aac1817">

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Check that the new not/between operators are there for the date fields but not for other field types where it doesn't make sense.
3. There is the new dual-input for for the filter value only when a not/between operator for the date field is selected.
4. Test that the contacts are added to the segment based on a custom object date field 
5. Test the filter field validation. Each of the 2 new inputs must be a date in the format as the calendar sets it. Example: Jan 5, 2024. Empty values and other values should be rejected.
6. Test both filters, the between but also the not between.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->