### PR TITLE
"in the last" and "in the next" segment filters.

### DIFF
--- a/CustomFieldType/DateTimeType.php
+++ b/CustomFieldType/DateTimeType.php
@@ -76,7 +76,7 @@ class DateTimeType extends AbstractCustomFieldType
     public function getOperators(): array
     {
         $allOperators     = parent::getOperators();
-        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty']);
+        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty', 'inLast', 'inNext']);
 
         return array_intersect_key($allOperators, $allowedOperators);
     }

--- a/CustomFieldType/DateType.php
+++ b/CustomFieldType/DateType.php
@@ -76,7 +76,7 @@ class DateType extends AbstractCustomFieldType
     public function getOperators(): array
     {
         $allOperators     = parent::getOperators();
-        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty']);
+        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty', 'inLast', 'inNext']);
 
         return array_intersect_key($allOperators, $allowedOperators);
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | No
| New feature/enhancement? (use the a.x branch)      | Yes
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

User should able to select the days/months/years unit in filter value with interval.
- ”In the last” works as between current date minus those days/months/year and current date.
- ”In the next” works as between current date plus those days/months/year and current date.

<img width="1109" alt="image" src="https://github.com/acquia/mc-cs-plugin-custom-objects/assets/68939488/eb451b07-5195-41c9-b0f7-bea1de8385d3">


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test "In the last" and "In the next" operator will be available for Date and DateTime type fields.
3. Test segment build with "In the last" and "In the next" operators.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->