### PR TITLE
MAUT-11467 : fix date issue if empty/not empty filter is used in segment filter

### DIFF
--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -184,6 +184,7 @@ class QueryFilterHelper
                     $customQuery->expr()->isNull($tableAlias.'_value.value'),
                 );
                 if ($filter->doesColumnSupportEmptyValue()) {
+                    /** @phpstan-ignore-next-line */
                     $expression->with(
                         $customQuery->expr()->eq($tableAlias.'_value.value', $customQuery->expr()->literal(''))
                     );
@@ -194,6 +195,7 @@ class QueryFilterHelper
                     $customQuery->expr()->isNotNull($tableAlias.'_value.value'),
                 );
                 if ($filter->doesColumnSupportEmptyValue()) {
+                    /** @phpstan-ignore-next-line */
                     $expression->with(
                         $customQuery->expr()->neq($tableAlias.'_value.value', $customQuery->expr()->literal(''))
                     );

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -184,8 +184,7 @@ class QueryFilterHelper
                     $customQuery->expr()->isNull($tableAlias.'_value.value'),
                 );
                 if ($filter->doesColumnSupportEmptyValue()) {
-                    /** @phpstan-ignore-next-line */
-                    $expression->with(
+                    $expression->add(
                         $customQuery->expr()->eq($tableAlias.'_value.value', $customQuery->expr()->literal(''))
                     );
                 }
@@ -195,8 +194,7 @@ class QueryFilterHelper
                     $customQuery->expr()->isNotNull($tableAlias.'_value.value'),
                 );
                 if ($filter->doesColumnSupportEmptyValue()) {
-                    /** @phpstan-ignore-next-line */
-                    $expression->with(
+                    $expression->add(
                         $customQuery->expr()->neq($tableAlias.'_value.value', $customQuery->expr()->literal(''))
                     );
                 }

--- a/Tests/Functional/Helper/QueryFilterHelperTest.php
+++ b/Tests/Functional/Helper/QueryFilterHelperTest.php
@@ -112,6 +112,34 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
                 ],
             ]
         );
+
+        $this->assertMatchWhere(
+            'test_value.value IS NULL',
+            [
+                'glue'       => 'and',
+                'field'      => 'cmf_'.$this->getFixtureById('custom_object_product')->getId(),
+                'object'     => 'custom_object',
+                'type'       => 'datetime',
+                'operator'   => 'empty',
+                'properties' => [
+                    'filter' => [],
+                ],
+            ]
+        );
+
+        $this->assertMatchWhere(
+            'test_value.value IS NOT NULL',
+            [
+                'glue'       => 'and',
+                'field'      => 'cmf_'.$this->getFixtureById('custom_object_product')->getId(),
+                'object'     => 'custom_object',
+                'type'       => 'datetime',
+                'operator'   => '!empty',
+                'properties' => [
+                    'filter' => [],
+                ],
+            ]
+        );
     }
 
     protected function assertMatchWhere(string $expectedWhere, array $filter): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-11467 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Segment with custom object filter not working field type is date and operator is empty in filter
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom object
3. Add date type field in custom object
4. Create segment
5. Add filter with empty operator on CO field created in step - 2
6. Rebuild segment 
7. Should not throw mysql query error

#### Other areas of Mautic that may be affected by the change:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1.
2. 
