### PR TITLE
Maut 11460: Dynamic content in email builder filtered on custom object values

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -868,6 +868,7 @@ $coParams = [
                     'mautic.campaign.model.event',
                     'event_dispatcher',
                     'custom_object.helper.token_formatter',
+                    '%mautic.custom_item_fetch_limit_per_lead%',
                 ],
             ],
             'custom_object.segments.decorator_delegate.subscriber'   => [
@@ -1189,10 +1190,11 @@ $coParams = [
         ],
     ],
     'parameters' => [
-        ConfigProvider::CONFIG_PARAM_ENABLED                                  => true,
-        ConfigProvider::CONFIG_PARAM_ITEM_VALUE_TO_CONTACT_RELATION_LIMIT     => ConfigProvider::CONFIG_PARAM_ITEM_VALUE_TO_CONTACT_RELATION_DEFAULT_LIMIT,
-        'custom_item_export_dir'                                              => '%kernel.root_dir%/../media/files/temp',
-        'custom_object_merge_filter'                                          => false,
+        ConfigProvider::CONFIG_PARAM_ENABLED                                           => true,
+        ConfigProvider::CONFIG_PARAM_ITEM_VALUE_TO_CONTACT_RELATION_LIMIT              => ConfigProvider::CONFIG_PARAM_ITEM_VALUE_TO_CONTACT_RELATION_DEFAULT_LIMIT,
+        'custom_item_export_dir'                                                       => '%kernel.root_dir%/../media/files/temp',
+        'custom_object_merge_filter'                                                   => false,
+        'custom_item_fetch_limit_per_lead'                                             => 15,
     ],
 ];
 

--- a/Config/config.php
+++ b/Config/config.php
@@ -863,6 +863,7 @@ $coParams = [
                     'custom_object.query.filter.factory',
                     'mautic.custom.model.object',
                     'mautic.custom.model.item',
+                    'mautic.custom.model.field',
                     'custom_object.token.parser',
                     'mautic.campaign.model.event',
                     'event_dispatcher',

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -48,6 +48,8 @@ class TokenSubscriber implements EventSubscriberInterface
     use MatchFilterForLeadTrait;
     use QueryBuilderManipulatorTrait;
 
+    private const CUSTOM_ITEMS_LIMIT = 15;
+
     /**
      * @var ConfigProvider
      */
@@ -462,7 +464,7 @@ class TokenSubscriber implements EventSubscriberInterface
         $orderBy  = CustomItem::TABLE_ALIAS.'.id';
         $orderDir = 'DESC';
 
-        $tableConfig = new TableConfig(15, 1, $orderBy, $orderDir);
+        $tableConfig = new TableConfig(self::CUSTOM_ITEMS_LIMIT, 1, $orderBy, $orderDir);
         $tableConfig->addParameter('customObjectId', $customObject->getId());
         $tableConfig->addParameter('filterEntityType', 'contact');
         $tableConfig->addParameter('filterEntityId', $leadId);

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -350,7 +350,7 @@ class TokenSubscriber implements EventSubscriberInterface
 
             $isCustomObject = false;
             foreach ($data['filters'] as $filter) {
-                $customFieldValues = $this->getCustomFieldDataForLead($filter['filters'], (int) $lead['id']);
+                $customFieldValues = $this->getCustomFieldDataForLead($filter['filters'], (string) $lead['id']);
 
                 foreach ($customFieldValues as $field => $values) {
                     foreach ($values as $value) {

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -549,11 +549,13 @@ class TokenSubscriber implements EventSubscriberInterface
                             break;
                         case 'datetime':
                         case 'time':
-                            $leadValCount   = substr_count($leadVal, ':');
-                            $filterValCount = substr_count($filterVal, ':');
+                            if (!is_null($leadVal) && !is_null($filterVal)) {
+                                $leadValCount   = substr_count($leadVal, ':');
+                                $filterValCount = substr_count($filterVal, ':');
 
-                            if (2 === $leadValCount && 1 === $filterValCount) {
-                                $filterVal .= ':00';
+                                if (2 === $leadValCount && 1 === $filterValCount) {
+                                    $filterVal .= ':00';
+                                }
                             }
                             break;
                         case 'tags':

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -571,7 +571,7 @@ class TokenSubscriber implements EventSubscriberInterface
                         case 'tags':
                         case 'select':
                         case 'multiselect':
-                            if (!is_null($leadVal) && !is_array($leadVal)) {
+                            if (!is_array($leadVal) && !empty($leadVal)) {
                                 $leadVal = explode('|', $leadVal);
                             }
                             if (!is_null($filterVal) && !is_array($filterVal)) {
@@ -618,13 +618,13 @@ class TokenSubscriber implements EventSubscriberInterface
                             $groups[$groupNum] = !empty($leadVal);
                             break;
                         case 'like':
-                            $filterVal         = str_replace(['.', '*', '%'], ['\.', '\*', '.*'], $filterVal);
-                            $groups[$groupNum] = 1 === preg_match('/'.$filterVal.'/', $leadVal);
+                            $matchVal          = str_replace(['.', '*', '%'], ['\.', '\*', '.*'], $filterVal);
+                            $groups[$groupNum] = 1 === preg_match('/'.$matchVal.'/', $leadVal);
                             break;
                         case '!like':
-                            $filterVal         = str_replace(['.', '*'], ['\.', '\*'], $filterVal);
-                            $filterVal         = str_replace('%', '.*', $filterVal);
-                            $groups[$groupNum] = 1 !== preg_match('/'.$filterVal.'/', $leadVal);
+                            $matchVal          = str_replace(['.', '*'], ['\.', '\*'], $filterVal);
+                            $matchVal          = str_replace('%', '.*', $matchVal);
+                            $groups[$groupNum] = 1 !== preg_match('/'.$matchVal.'/', $leadVal);
                             break;
                         case OperatorOptions::IN:
                             $groups[$groupNum] = $this->checkLeadValueIsInFilter($leadVal, $filterVal, false);

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -452,7 +452,12 @@ class TokenSubscriber implements EventSubscriberInterface
                 if (empty($fieldValue->getValue())) {
                     $fieldValue->setValue($fieldValue->getCustomField()->getDefaultValue());
                 }
-                $fieldValues[] = $fieldValue->getValue();
+
+                if (in_array($fieldValue->getCustomField()->getType(), ['multiselect', 'select'])) {
+                    $fieldValues[] = $fieldValue->getValue();
+                } else {
+                    $fieldValues[] = $fieldValue->getCustomField()->getTypeObject()->valueToString($fieldValue);
+                }
             } catch (NotFoundException $e) {
                 // Custom field not found.
             }
@@ -528,6 +533,7 @@ class TokenSubscriber implements EventSubscriberInterface
             }
 
             $leadValues   = $lead[$data['field']];
+            $leadValues   = 'custom_object' === $data['object'] ? $leadValues : [$leadValues];
             $filterVal    = $data['filter'];
             $subgroup     = null;
 

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -452,7 +452,7 @@ class TokenSubscriber implements EventSubscriberInterface
                 if (empty($fieldValue->getValue())) {
                     $fieldValue->setValue($fieldValue->getCustomField()->getDefaultValue());
                 }
-                $fieldValues[] = $fieldValue->getCustomField()->getTypeObject()->valueToString($fieldValue);
+                $fieldValues[] = $fieldValue->getValue();
             } catch (NotFoundException $e) {
                 // Custom field not found.
             }

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -456,7 +456,7 @@ class TokenSubscriber implements EventSubscriberInterface
     private function getCustomItems(CustomObject $customObject, int $leadId): array
     {
         $key = $customObject->getAlias().'-'.$leadId;
-        if ($this->customItems[$key]) {
+        if (isset($this->customItems[$key])) {
             return $this->customItems[$key];
         }
 

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -428,11 +428,15 @@ class TokenSubscriber implements EventSubscriberInterface
                 }
 
                 if ('cmf_' === substr($condition['field'], 0, 4)) {
-                    $customField  = $this->customFieldModel->fetchEntity((int) explode('cmf_', $condition['field'])[1]);
+                    $customField  = $this->customFieldModel->fetchEntity(
+                        (int) explode('cmf_', $condition['field'])[1]
+                    );
                     $customObject = $customField->getCustomObject();
                     $fieldAlias   = $customField->getAlias();
                 } elseif ('cmo_' === substr($condition['field'], 0, 4)) {
-                    $customObject = $this->customObjectModel->fetchEntity((int) explode('cmo_', $condition['field'])[1]);
+                    $customObject = $this->customObjectModel->fetchEntity(
+                        (int) explode('cmo_', $condition['field'])[1]
+                    );
                     $fieldAlias   = 'name';
                 } else {
                     continue;

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -380,7 +380,7 @@ class TokenSubscriber implements EventSubscriberInterface
         $tableConfig = new TableConfig(1, 1, $orderBy, $orderDir);
         $tableConfig->addParameter('customObjectId', $customObject->getId());
         $tableConfig->addParameter('filterEntityType', 'contact');
-        $tableConfig->addParameter('filterEntityId', (int) $id);
+        $tableConfig->addParameter('filterEntityId', $id);
         $tableConfig->addParameter('token', $customFieldAlias);
         $customItems = $this->customItemModel->getArrayTableData($tableConfig);
         $fieldValues = [];

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -429,8 +429,11 @@ class TokenSubscriber implements EventSubscriberInterface
      *
      * @return array<mixed>
      */
-    private function getCustomFieldValue(CustomObject $customObject, string $customFieldAlias, array $customItems): array
-    {
+    private function getCustomFieldValue(
+        CustomObject $customObject,
+        string $customFieldAlias,
+        array $customItems
+    ): array {
         $fieldValues = [];
 
         foreach ($customItems as $customItemData) {
@@ -482,7 +485,8 @@ class TokenSubscriber implements EventSubscriberInterface
         return $this->customItemModel->getArrayTableData($tableConfig);
     }
 
-    // We have a similar function in MatchFilterForLeadTrait since we are unable to alter anything in Mautic 4.4, hence there is some duplication of code.
+    // We have a similar function in MatchFilterForLeadTrait since we are unable to alter anything in Mautic 4.4,
+    // hence there is some duplication of code.
 
     /**
      * @param array<mixed> $filter

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -399,7 +399,7 @@ class TokenSubscriber implements EventSubscriberInterface
                     continue;
                 }
 
-                $key = $customObject->getAlias().'-'.$leadId;
+                $key = $customObject->getId().'-'.$leadId;
                 if (!isset($cachedCustomItems[$key])) {
                     $cachedCustomItems[$key] = $this->getCustomItems($customObject, $leadId);
                 }

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -455,7 +455,7 @@ class TokenSubscriber implements EventSubscriberInterface
     /**
      * @return array<mixed>
      */
-    private function getCustomItems(CustomObject $customObject, int $leadId): array
+    private function getCustomItems(CustomObject $customObject, string $leadId): array
     {
         $orderBy  = CustomItem::TABLE_ALIAS.'.id';
         $orderDir = 'DESC';

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -374,7 +374,7 @@ class TokenSubscriber implements EventSubscriberInterface
      *
      * @return array<mixed>
      */
-    private function getCustomFieldDataForLead(array $filters, int $leadId): array
+    private function getCustomFieldDataForLead(array $filters, string $leadId): array
     {
         $customFieldValues = $cachedCustomItems = [];
 

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -96,6 +96,11 @@ class TokenSubscriber implements EventSubscriberInterface
      */
     private $tokenFormatter;
 
+    /**
+     * @var array<mixed>
+     */
+    private $customItems;
+
     public function __construct(
         ConfigProvider $configProvider,
         QueryFilterHelper $queryFilterHelper,
@@ -374,15 +379,7 @@ class TokenSubscriber implements EventSubscriberInterface
      */
     private function getCustomFieldValue(CustomObject $customObject, int $id, string $customFieldAlias): string
     {
-        $orderBy  = CustomItem::TABLE_ALIAS.'.id';
-        $orderDir = 'DESC';
-
-        $tableConfig = new TableConfig(1, 1, $orderBy, $orderDir);
-        $tableConfig->addParameter('customObjectId', $customObject->getId());
-        $tableConfig->addParameter('filterEntityType', 'contact');
-        $tableConfig->addParameter('filterEntityId', $id);
-        $tableConfig->addParameter('token', $customFieldAlias);
-        $customItems = $this->customItemModel->getArrayTableData($tableConfig);
+        $customItems = $this->getCustomItems($customObject, $id);
         $fieldValues = [];
 
         foreach ($customItems as $customItemData) {
@@ -451,5 +448,27 @@ class TokenSubscriber implements EventSubscriberInterface
         }
 
         return $customFieldValues;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function getCustomItems(CustomObject $customObject, int $leadId): array
+    {
+        $key = $customObject->getAlias().'-'.$leadId;
+        if ($this->customItems[$key]) {
+            return $this->customItems[$key];
+        }
+
+        $orderBy  = CustomItem::TABLE_ALIAS.'.id';
+        $orderDir = 'DESC';
+
+        $tableConfig = new TableConfig(1, 1, $orderBy, $orderDir);
+        $tableConfig->addParameter('customObjectId', $customObject->getId());
+        $tableConfig->addParameter('filterEntityType', 'contact');
+        $tableConfig->addParameter('filterEntityId', $leadId);
+        $this->customItems[$key] = $this->customItemModel->getArrayTableData($tableConfig);
+
+        return $this->customItems[$key];
     }
 }

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -352,14 +352,18 @@ class TokenSubscriber implements EventSubscriberInterface
             foreach ($data['filters'] as $filter) {
                 $customFieldValues = $this->getCustomFieldDataForLead($filter['filters'], (int) $lead['id']);
 
-                if (!empty($customFieldValues)) {
-                    $isCustomObject = true;
-                    $lead           = array_merge($lead, $customFieldValues);
-                }
+                foreach ($customFieldValues as $field => $values) {
+                    foreach ($values as $value) {
+                        if (!empty($value)) {
+                            $isCustomObject = true;
+                            $lead = array_merge($lead, [$field => $value]);
+                        }
 
-                if ($isCustomObject && $this->matchFilterForLead($filter['filters'], $lead)) {
-                    $filterContent = $filter['content'];
-                    break;
+                        if ($isCustomObject && $this->matchFilterForLead($filter['filters'], $lead)) {
+                            $filterContent = $filter['content'];
+                            break;
+                        }
+                    }
                 }
             }
 
@@ -420,7 +424,7 @@ class TokenSubscriber implements EventSubscriberInterface
      *
      * @throws InvalidCustomObjectFormatListException
      */
-    private function getCustomFieldValue(CustomObject $customObject, string $customFieldAlias, array $customItems): string
+    private function getCustomFieldValue(CustomObject $customObject, string $customFieldAlias, array $customItems)
     {
         $fieldValues = [];
 
@@ -449,7 +453,7 @@ class TokenSubscriber implements EventSubscriberInterface
             }
         }
 
-        return $this->tokenFormatter->format($fieldValues, TokenFormatter::DEFAULT_FORMAT);
+        return $fieldValues;
     }
 
     /**
@@ -460,7 +464,7 @@ class TokenSubscriber implements EventSubscriberInterface
         $orderBy  = CustomItem::TABLE_ALIAS.'.id';
         $orderDir = 'DESC';
 
-        $tableConfig = new TableConfig(1, 1, $orderBy, $orderDir);
+        $tableConfig = new TableConfig(15, 1, $orderBy, $orderDir);
         $tableConfig->addParameter('customObjectId', $customObject->getId());
         $tableConfig->addParameter('filterEntityType', 'contact');
         $tableConfig->addParameter('filterEntityId', $leadId);

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -48,8 +48,6 @@ class TokenSubscriber implements EventSubscriberInterface
     use MatchFilterForLeadTrait;
     use QueryBuilderManipulatorTrait;
 
-    private const CUSTOM_ITEMS_LIMIT = 15;
-
     /**
      * @var ConfigProvider
      */
@@ -100,6 +98,11 @@ class TokenSubscriber implements EventSubscriberInterface
      */
     private $tokenFormatter;
 
+    /**
+     * @var int
+     */
+    private $leadCustomItemFetchLimit;
+
     public function __construct(
         ConfigProvider $configProvider,
         QueryFilterHelper $queryFilterHelper,
@@ -110,18 +113,20 @@ class TokenSubscriber implements EventSubscriberInterface
         TokenParser $tokenParser,
         EventModel $eventModel,
         EventDispatcherInterface $eventDispatcher,
-        TokenFormatter $tokenFormatter
+        TokenFormatter $tokenFormatter,
+        int $leadCustomItemFetchLimit
     ) {
-        $this->configProvider     = $configProvider;
-        $this->queryFilterHelper  = $queryFilterHelper;
-        $this->queryFilterFactory = $queryFilterFactory;
-        $this->customObjectModel  = $customObjectModel;
-        $this->customItemModel    = $customItemModel;
-        $this->customFieldModel   = $customFieldModel;
-        $this->tokenParser        = $tokenParser;
-        $this->eventModel         = $eventModel;
-        $this->eventDispatcher    = $eventDispatcher;
-        $this->tokenFormatter     = $tokenFormatter;
+        $this->configProvider                    = $configProvider;
+        $this->queryFilterHelper                 = $queryFilterHelper;
+        $this->queryFilterFactory                = $queryFilterFactory;
+        $this->customObjectModel                 = $customObjectModel;
+        $this->customItemModel                   = $customItemModel;
+        $this->customFieldModel                  = $customFieldModel;
+        $this->tokenParser                       = $tokenParser;
+        $this->eventModel                        = $eventModel;
+        $this->eventDispatcher                   = $eventDispatcher;
+        $this->tokenFormatter                    = $tokenFormatter;
+        $this->leadCustomItemFetchLimit          = $leadCustomItemFetchLimit;
     }
 
     /**
@@ -464,7 +469,7 @@ class TokenSubscriber implements EventSubscriberInterface
         $orderBy  = CustomItem::TABLE_ALIAS.'.id';
         $orderDir = 'DESC';
 
-        $tableConfig = new TableConfig(self::CUSTOM_ITEMS_LIMIT, 1, $orderBy, $orderDir);
+        $tableConfig = new TableConfig($this->leadCustomItemFetchLimit, 1, $orderBy, $orderDir);
         $tableConfig->addParameter('customObjectId', $customObject->getId());
         $tableConfig->addParameter('filterEntityType', 'contact');
         $tableConfig->addParameter('filterEntityId', $leadId);

--- a/EventListener/TokenSubscriber.php
+++ b/EventListener/TokenSubscriber.php
@@ -7,6 +7,7 @@ namespace MauticPlugin\CustomObjectsBundle\EventListener;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Model\EventModel;
 use Mautic\CoreBundle\Event\BuilderEvent;
+use Mautic\CoreBundle\Event\TokenReplacementEvent;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
@@ -121,6 +122,7 @@ class TokenSubscriber implements EventSubscriberInterface
             EmailEvents::EMAIL_ON_SEND                       => ['decodeTokens', 0],
             EmailEvents::EMAIL_ON_DISPLAY                    => ['decodeTokens', 0],
             CustomItemEvents::ON_CUSTOM_ITEM_LIST_DBAL_QUERY => ['onListQuery', -1],
+            EmailEvents::TOKEN_REPLACEMENT                   => ['onTokenReplacement', 100],
         ];
     }
 
@@ -322,5 +324,90 @@ class TokenSubscriber implements EventSubscriberInterface
         }
 
         return $fieldValues;
+    }
+
+    public function onTokenReplacement(TokenReplacementEvent $event): void
+    {
+        $clickthrough = $event->getClickthrough();
+
+        if (!array_key_exists('dynamicContent', $clickthrough)) {
+            return;
+        }
+
+        $lead      = $event->getLead();
+        $tokenData = $clickthrough['dynamicContent'];
+
+        foreach ($tokenData as $data) {
+            // Default content
+            $filterContent = $data['content'];
+
+            foreach ($data['filters'] as $filter) {
+                foreach ($filter['filters'] as $condition) {
+                    if ('custom_object' !== $condition['object'] || empty($condition['display'])) {
+                        continue;
+                    }
+
+                    list($customObjectAlias, $customItemAlias) = array_map(
+                        function ($part) {
+                            return trim($part);
+                        }, explode(':', $condition['display']));
+
+                    $customObject              = $this->customObjectModel->fetchEntityByAlias($customObjectAlias);
+                    $result                    = $this->getCustomItemValue($customObject, (int) $lead['id'], $customItemAlias);
+                    $lead[$condition['field']] = $result;
+                }
+
+                if ($this->matchFilterForLead($filter['filters'], $lead)) {
+                    $filterContent = $filter['content'];
+                    break;
+                }
+            }
+
+            $event->addToken('{dynamiccontent="'.$data['tokenName'].'"}', $filterContent);
+        }
+    }
+
+    /**
+     * @throws InvalidCustomObjectFormatListException
+     */
+    public function getCustomItemValue(CustomObject $customObject, int $id, string $customItemAlias): string
+    {
+        $orderBy  = CustomItem::TABLE_ALIAS.'.id';
+        $orderDir = 'DESC';
+
+        $tableConfig = new TableConfig(1, 1, $orderBy, $orderDir);
+        $tableConfig->addParameter('customObjectId', $customObject->getId());
+        $tableConfig->addParameter('filterEntityType', 'contact');
+        $tableConfig->addParameter('filterEntityId', (int) $id);
+        $tableConfig->addParameter('token', $customItemAlias);
+        $customItems = $this->customItemModel->getArrayTableData($tableConfig);
+        $fieldValues = [];
+
+        foreach ($customItems as $customItemData) {
+            // Name is known from the CI data array.
+            if ('name' === $customItemAlias) {
+                $fieldValues[] = $customItemData['name'];
+
+                continue;
+            }
+
+            // Custom Field values are handled like this.
+            $customItem = new CustomItem($customObject);
+            $customItem->populateFromArray($customItemData);
+            $customItem = $this->customItemModel->populateCustomFields($customItem);
+
+            try {
+                $fieldValue = $customItem->findCustomFieldValueForFieldAlias($customItemAlias);
+                // If the CO item doesn't have a value, get the default value
+                if (empty($fieldValue->getValue())) {
+                    $fieldValue->setValue($fieldValue->getCustomField()->getDefaultValue());
+                }
+                $fieldValues[] = $fieldValue->getCustomField()->getTypeObject()->valueToString($fieldValue);
+            } catch (NotFoundException $e) {
+                // Custom field not found.
+            }
+        }
+
+        return $this->tokenFormatter->format($fieldValues, TokenFormatter::DEFAULT_FORMAT);
     }
 }

--- a/Tests/Functional/PreviewFunctionalTest.php
+++ b/Tests/Functional/PreviewFunctionalTest.php
@@ -74,7 +74,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
                             'filters' => [
                                 [
                                     'glue'     => 'and',
-                                    'field'    => 'cmf_1',
+                                    'field'    => 'cmf_'.$textValue->getCustomField()->getId(),
                                     'object'   => 'custom_object',
                                     'type'     => 'text',
                                     'filter'   => 'abracadabra',

--- a/Tests/Functional/PreviewFunctionalTest.php
+++ b/Tests/Functional/PreviewFunctionalTest.php
@@ -12,12 +12,14 @@ use MauticPlugin\CustomObjectsBundle\Entity\CustomItem;
 use MauticPlugin\CustomObjectsBundle\Model\CustomFieldValueModel;
 use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
 use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\CustomObjectsTrait;
+use MauticPlugin\CustomObjectsBundle\Tests\ProjectVersionTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class PreviewFunctionalTest extends MauticMysqlTestCase
 {
     use CustomObjectsTrait;
+    use ProjectVersionTrait;
 
     /**
      * @var CustomItemModel
@@ -39,6 +41,10 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
 
     public function testPreviewPageCODynamicContent(): void
     {
+        if (!$this->isCloudProject()) {
+            $this->markTestSkipped('Not supported in 4.4');
+        }
+
         $customObject = $this->createCustomObjectWithAllFields(self::$container, 'Car');
         $customItem   = new CustomItem($customObject);
 

--- a/Tests/Functional/PreviewFunctionalTest.php
+++ b/Tests/Functional/PreviewFunctionalTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Functional;
+
+use DateTime;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\LeadBundle\Entity\Lead;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomItem;
+use MauticPlugin\CustomObjectsBundle\Model\CustomFieldValueModel;
+use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
+use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\CustomObjectsTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PreviewFunctionalTest extends MauticMysqlTestCase
+{
+    use CustomObjectsTrait;
+
+    /**
+     * @var CustomItemModel
+     */
+    private $customItemModel;
+
+    /**
+     * @var CustomFieldValueModel
+     */
+    private $customFieldValueModel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->customItemModel       = self::$container->get('mautic.custom.model.item');
+        $this->customFieldValueModel = self::$container->get('mautic.custom.model.field.value');
+    }
+
+    public function testPreviewPageCODynamicContent(): void
+    {
+        $customObject = $this->createCustomObjectWithAllFields(self::$container, 'Car');
+        $customItem   = new CustomItem($customObject);
+
+        $customItem->setName('Nexon');
+        $this->customFieldValueModel->createValuesForItem($customItem);
+
+        $textValue       = $customItem->findCustomFieldValueForFieldAlias('text-test-field');
+        $textValue->setValue('abracadabra');
+
+        $customItem = $this->customItemModel->save($customItem);
+
+        $lead  = $this->createLead();
+        $email = $this->createEmail();
+        $email->setDynamicContent(
+            [
+                [
+                    'tokenName' => 'Dynamic Content 1',
+                    'content'   => 'Default Dynamic Content',
+                    'filters'   => [
+                        [
+                            'content' => null,
+                            'filters' => [
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'tokenName' => 'Dynamic Content 2',
+                    'content'   => 'Default Dynamic Content',
+                    'filters'   => [
+                        [
+                            'content' => 'Nexon Dynamic Content',
+                            'filters' => [
+                                [
+                                    'glue'     => 'and',
+                                    'field'    => 'cmf_1',
+                                    'object'   => 'custom_object',
+                                    'type'     => 'text',
+                                    'filter'   => 'abracadabra',
+                                    'display'  => $customObject->getAlias().':text-test-field',
+                                    'operator' => '=',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->em->persist($email);
+        $this->em->flush();
+
+        $this->customItemModel->linkEntity($customItem, 'contact', $lead->getId());
+
+        $url                    = "/email/preview/{$email->getId()}";
+        $urlWithContact         = "{$url}?contactId={$lead->getId()}";
+        $contentNoContactInfo   = 'Default Dynamic Content';
+        $contentWithContactInfo = 'Nexon Dynamic Content';
+
+        // Anonymous visitor
+        $this->assertPageContent($url, $contentNoContactInfo);
+        $this->assertPageContent($urlWithContact, $contentNoContactInfo);
+
+        $this->loginUser('admin');
+
+        // Admin user
+        $this->assertPageContent($url, $contentNoContactInfo);
+        $this->assertPageContent($urlWithContact, $contentWithContactInfo);
+    }
+
+    private function assertPageContent(string $url, string ...$expectedContents): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, $url);
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        foreach ($expectedContents as $expectedContent) {
+            self::assertStringContainsString($expectedContent, $crawler->text());
+        }
+    }
+
+    private function createEmail(bool $publicPreview = true): Email
+    {
+        $email = new Email();
+        $email->setDateAdded(new DateTime());
+        $email->setName('Email name');
+        $email->setSubject('Email subject');
+        $email->setTemplate('Blank');
+        $email->setPublicPreview($publicPreview);
+        $email->setCustomHtml('<html><body>{dynamiccontent="Dynamic Content 2"}</body></html>');
+        $this->em->persist($email);
+
+        return $email;
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setEmail('test@domain.tld');
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+}

--- a/Tests/Functional/PreviewFunctionalTest.php
+++ b/Tests/Functional/PreviewFunctionalTest.php
@@ -90,7 +90,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($email);
         $this->em->flush();
 
-        $this->customItemModel->linkEntity($customItem, 'contact', $lead->getId());
+        $this->customItemModel->linkEntity($customItem, 'contact', (int) $lead->getId());
 
         $url                    = "/email/preview/{$email->getId()}";
         $urlWithContact         = "{$url}?contactId={$lead->getId()}";

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -72,6 +72,9 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
         $this->customFieldValues['nexon-multiselect']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('multiselect-test-field');
         $this->customFieldValues['nexon-multiselect']->setValue('option_a');
 
+        $this->customFieldValues['nexon-number']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('number-test-field');
+        $this->customFieldValues['nexon-number']->setValue(10);
+
         $this->customItems['nexon'] = $this->customItemModel->save($this->customItems['nexon']);
 
         $this->customItems['fortuner']   = new CustomItem($this->customObject);
@@ -102,6 +105,7 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                  'nexonmultiselect@acquia.com',
                  $this->buildDynamicContentArray([
                      ['nexon-datetime', null, '!empty', 'datetime'],
+                     ['nexon-number', 12, 'lt', 'number'],
                  ]),
                  'Custom Object Dynamic Content',
              ], [

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -71,7 +71,6 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
 
         $this->customFieldValues['nexon-multiselect']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('multiselect-test-field');
         $this->customFieldValues['nexon-multiselect']->setValue('option_a');
-        $this->customFieldValues['nexon-multiselect']->setValue('option_b');
 
         $this->customItems['nexon'] = $this->customItemModel->save($this->customItems['nexon']);
 
@@ -107,8 +106,14 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                      ['nexon-multiselect', '"Option A"', 'in'],
                  ]),
                  'Custom Object Dynamic Content',
-             ],
-            [
+             ], [
+                'nexondatetime@acquia.com',
+                $this->buildDynamicContentArray([
+                    ['nexon-text', 'Tata', '='],
+                    ['nexon-datetime', '2024-07-01', 'gte'],
+                ]),
+                'Custom Object Dynamic Content',
+            ], [
                 'nexonequal@acquia.com',
                 $this->buildDynamicContentArray([
                     ['nexon-text', 'Tata', '='],
@@ -146,14 +151,7 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                  'nexonendsWith@acquia.com',
                  $this->buildDynamicContentArray([['nexon-text', 'at', 'contains']]),
                  'Custom Object Dynamic Content',
-             ], [
-                'nexondatetime@acquia.com',
-                $this->buildDynamicContentArray([
-                    ['nexon-text', 'Tata', '='],
-                    ['nexon-datetime', '2024-07-01', 'gte'],
-                ]),
-                'Custom Object Dynamic Content',
-            ],
+             ],
         ] as $item) {
             $this->emailWithCustomObjectDynamicContent($item[0], $item[1], $item[2]);
         }

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -109,7 +109,7 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                  $this->buildDynamicContentArray([
                      ['nexon-text', 'Tata', '='],
                      ['nexon-datetime', '2024-07-01', 'gte'],
-                     ['nexon-multiselect', '"Option A"', 'in'],
+                     ['nexon-multiselect', 'option_a', 'in'],
                  ]),
                  'Custom Object Dynamic Content',
              ], [

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -2,24 +2,27 @@
 
 declare(strict_types=1);
 
-namespace MauticPlugin\CustomObjectsBundle\Tests\Functional;
+namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\Token;
 
 use DateTime;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Entity\Lead;
 use MauticPlugin\CustomObjectsBundle\Entity\CustomItem;
 use MauticPlugin\CustomObjectsBundle\Model\CustomFieldValueModel;
 use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
 use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\CustomObjectsTrait;
-use MauticPlugin\CustomObjectsBundle\Tests\ProjectVersionTrait;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PreviewFunctionalTest extends MauticMysqlTestCase
+class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestCase
 {
     use CustomObjectsTrait;
-    use ProjectVersionTrait;
 
     /**
      * @var CustomItemModel
@@ -39,12 +42,8 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         $this->customFieldValueModel = self::$container->get('mautic.custom.model.field.value');
     }
 
-    public function testPreviewPageCODynamicContent(): void
+    public function testEmailWithCustomObjectDynamicContent(): void
     {
-        if (!$this->isCloudProject()) {
-            $this->markTestSkipped('Not supported in 4.4');
-        }
-
         $customObject = $this->createCustomObjectWithAllFields(self::$container, 'Car');
         $customItem   = new CustomItem($customObject);
 
@@ -52,11 +51,12 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         $this->customFieldValueModel->createValuesForItem($customItem);
 
         $textValue       = $customItem->findCustomFieldValueForFieldAlias('text-test-field');
-        $textValue->setValue('abracadabra');
+        $textValue->setValue('Tata');
 
         $customItem = $this->customItemModel->save($customItem);
 
-        $lead  = $this->createLead();
+        $lead1  = $this->createLead('nexon@tata.com');
+        $lead2  = $this->createLead('noitem@tata.com');
         $email = $this->createEmail();
         $email->setDynamicContent(
             [
@@ -83,8 +83,17 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
                                     'field'    => 'cmf_'.$textValue->getCustomField()->getId(),
                                     'object'   => 'custom_object',
                                     'type'     => 'text',
-                                    'filter'   => 'abracadabra',
-                                    'display'  => $customObject->getAlias().':text-test-field',
+                                    'filter'   => 'Tata',
+                                    'display'  => $customObject->getAlias().': text-test-field',
+                                    'operator' => '=',
+                                ],
+                                [
+                                    'glue'     => 'and',
+                                    'field'    => 'cmo_'.$customObject->getId(),
+                                    'object'   => 'custom_object',
+                                    'type'     => 'text',
+                                    'filter'   => 'Nexon',
+                                    'display'  => $customObject->getAlias(),
                                     'operator' => '=',
                                 ],
                             ],
@@ -96,31 +105,10 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($email);
         $this->em->flush();
 
-        $this->customItemModel->linkEntity($customItem, 'contact', (int) $lead->getId());
+        $this->customItemModel->linkEntity($customItem, 'contact', (int) $lead1->getId());
 
-        $url                    = "/email/preview/{$email->getId()}";
-        $urlWithContact         = "{$url}?contactId={$lead->getId()}";
-        $contentNoContactInfo   = 'Default Dynamic Content';
-        $contentWithContactInfo = 'Nexon Dynamic Content';
-
-        // Anonymous visitor
-        $this->assertPageContent($url, $contentNoContactInfo);
-        $this->assertPageContent($urlWithContact, $contentNoContactInfo);
-
-        $this->loginUser('admin');
-
-        // Admin user
-        $this->assertPageContent($url, $contentNoContactInfo);
-        $this->assertPageContent($urlWithContact, $contentWithContactInfo);
-    }
-
-    private function assertPageContent(string $url, string ...$expectedContents): void
-    {
-        $crawler = $this->client->request(Request::METHOD_GET, $url);
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
-        foreach ($expectedContents as $expectedContent) {
-            self::assertStringContainsString($expectedContent, $crawler->text());
-        }
+        $this->sendAndAssetText($email, $lead1, 'Nexon Dynamic Content');
+        $this->sendAndAssetText($email, $lead2, 'Default Dynamic Content');
     }
 
     private function createEmail(bool $publicPreview = true): Email
@@ -137,12 +125,66 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         return $email;
     }
 
-    private function createLead(): Lead
+    private function createLead(string $email): Lead
     {
         $lead = new Lead();
-        $lead->setEmail('test@domain.tld');
+        $lead->setEmail($email);
         $this->em->persist($lead);
 
         return $lead;
+    }
+
+    /**
+     * @param EmailModel $emailModel
+     * @param Email $email
+     * @param Lead $lead
+     * @param StatRepository $emailStatRepository
+     * @return void
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function sendAndAssetText(Email $email, Lead $lead, string $matchText): void
+    {
+        /** @var EmailModel $emailModel */
+        $emailModel = self::$container->get('mautic.email.model.email');
+        $emailModel->sendEmail(
+            $email,
+            [
+                [
+                    'id' => $lead->getId(),
+                    'email' => $lead->getEmail(),
+                    'firstname' => $lead->getFirstname(),
+                    'lastname' => $lead->getLastname(),
+                ],
+            ]
+        );
+
+        /** @var StatRepository $emailStatRepository */
+        $emailStatRepository = $this->em->getRepository(Stat::class);
+
+        /** @var Stat|null $emailStat */
+        $emailStat = $emailStatRepository->findOneBy(
+            [
+                'email' => $email->getId(),
+                'lead' => $lead->getId(),
+            ]
+        );
+
+        Assert::assertNotNull($emailStat);
+
+        $crawler = $this->client->request(Request::METHOD_GET, "/email/view/{$emailStat->getTrackingHash()}");
+
+        $body = $crawler->filter('body');
+
+        // Remove the tracking tags that are causing troubles with different Mautic configurations.
+        $body->filter('a,img,div')->each(function (Crawler $crawler) {
+            foreach ($crawler as $node) {
+                $node->parentNode->removeChild($node);
+            }
+        });
+
+        Assert::assertStringContainsString(
+            $matchText,
+            $body->html()
+        );
     }
 }

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -188,17 +188,29 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                 'filters'   => [
                     [
                         'content' => 'Custom Object Dynamic Content',
-                        'filters' => array_map(function ($input) {
-                            return [
-                                'glue'     => 'and',
-                                'field'    => 'cmf_'.$this->customFieldValues[$input[0]]->getCustomField()->getId(),
-                                'object'   => 'custom_object',
-                                'type'     => $input[3] ?? 'text',
-                                'filter'   => $input[1],
-                                'display'  => $this->customObject->getName().':'.$this->customFieldValues[$input[0]]->getCustomField()->getLabel(),
-                                'operator' => $input[2],
-                            ];
-                        }, $inputs),
+                        'filters' => array_merge(
+                            array_map(function ($input) {
+                                return [
+                                        'glue'     => 'and',
+                                        'field'    => 'cmf_'.$this->customFieldValues[$input[0]]->getCustomField()->getId(),
+                                        'object'   => 'custom_object',
+                                        'type'     => $input[3] ?? 'text',
+                                        'filter'   => $input[1],
+                                        'display'  => $this->customObject->getName().':'.$this->customFieldValues[$input[0]]->getCustomField()->getLabel(),
+                                        'operator' => $input[2],
+                                    ];
+                            }, $inputs),
+                            [
+                                [
+                                    'glue'     => 'and',
+                                    'field'    => 'email',
+                                    'object'   => 'lead',
+                                    'type'     => 'email',
+                                    'filter'   => null,
+                                    'operator' => '!empty',
+                                ],
+                            ]
+                        ),
                     ],
                 ],
             ],

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -101,6 +101,12 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
              [
                  'nexonmultiselect@acquia.com',
                  $this->buildDynamicContentArray([
+                     ['nexon-datetime', null, '!empty', 'datetime']
+                 ]),
+                 'Custom Object Dynamic Content',
+             ], [
+                 'nexonmultiselect@acquia.com',
+                 $this->buildDynamicContentArray([
                      ['nexon-text', 'Tata', '='],
                      ['nexon-datetime', '2024-07-01', 'gte'],
                      ['nexon-multiselect', '"Option A"', 'in'],
@@ -187,7 +193,7 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                                 'glue'     => 'and',
                                 'field'    => 'cmf_'.$this->customFieldValues[$input[0]]->getCustomField()->getId(),
                                 'object'   => 'custom_object',
-                                'type'     => 'text',
+                                'type'     => $input[3] ?? 'text',
                                 'filter'   => $input[1],
                                 'display'  => $this->customObject->getName().':'.$this->customFieldValues[$input[0]]->getCustomField()->getLabel(),
                                 'operator' => $input[2],

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -108,8 +108,8 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                  'nexonmultiselect@acquia.com',
                  $this->buildDynamicContentArray([
                      ['nexon-text', 'Tata', '='],
-                     ['nexon-datetime', '2024-07-01', 'gte'],
-                     ['nexon-multiselect', 'option_a', 'in'],
+                     ['nexon-datetime', '2024-07-01 00:00', 'gte', 'datetime'],
+                     ['nexon-multiselect', 'option_a', 'in', 'multiselect'],
                  ]),
                  'Custom Object Dynamic Content',
              ], [

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -161,6 +161,7 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
 
     /**
      * @param array<mixed> $inputs
+     *
      * @return array<mixed>
      */
     private function buildDynamicContentArray(array $inputs): array
@@ -184,16 +185,16 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                     [
                         'content' => 'Custom Object Dynamic Content',
                         'filters' => array_map(function ($input) {
-                                return [
-                                    'glue'     => 'and',
-                                    'field'    => 'cmf_'.$this->customFieldValues[$input[0]]->getCustomField()->getId(),
-                                    'object'   => 'custom_object',
-                                    'type'     => 'text',
-                                    'filter'   => $input[1],
-                                    'display'  => $this->customObject->getName().':'.$this->customFieldValues[$input[0]]->getCustomField()->getLabel(),
-                                    'operator' => $input[2],
-                                ];
-                            }, $inputs),
+                            return [
+                                'glue'     => 'and',
+                                'field'    => 'cmf_'.$this->customFieldValues[$input[0]]->getCustomField()->getId(),
+                                'object'   => 'custom_object',
+                                'type'     => 'text',
+                                'filter'   => $input[1],
+                                'display'  => $this->customObject->getName().':'.$this->customFieldValues[$input[0]]->getCustomField()->getLabel(),
+                                'operator' => $input[2],
+                            ];
+                        }, $inputs),
                     ],
                 ],
             ],

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -101,7 +101,7 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
              [
                  'nexonmultiselect@acquia.com',
                  $this->buildDynamicContentArray([
-                     ['nexon-datetime', null, '!empty', 'datetime']
+                     ['nexon-datetime', null, '!empty', 'datetime'],
                  ]),
                  'Custom Object Dynamic Content',
              ], [

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -72,6 +72,11 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
         $this->customFieldValues['nexon-multiselect']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('multiselect-test-field');
         $this->customFieldValues['nexon-multiselect']->setValue('option_a');
 
+        $this->customFieldValues['nexon-select']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('select-test-field');
+
+        $this->customFieldValues['nexon-url']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('url-test-field');
+        $this->customFieldValues['nexon-url']->setValue('https://test.mautic.fr');
+
         $this->customFieldValues['nexon-number']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('number-test-field');
         $this->customFieldValues['nexon-number']->setValue(10);
 
@@ -101,6 +106,20 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
     public function testDynamicContentEmail(): void
     {
         foreach ([
+             [
+                 'nexonlikeurl@acquia.com',
+                 $this->buildDynamicContentArray([
+                     ['nexon-url', 'tic.f', 'like'],
+                 ]),
+                 'Custom Object Dynamic Content',
+             ],
+             [
+                 'nexonselect@acquia.com',
+                 $this->buildDynamicContentArray([
+                     ['nexon-select', null, 'empty', 'select'],
+                 ]),
+                 'Custom Object Dynamic Content',
+             ],
              [
                  'nexonmultiselect@acquia.com',
                  $this->buildDynamicContentArray([

--- a/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
+++ b/Tests/Functional/Token/EmailWithCustomObjectDynamicContentFunctionalTest.php
@@ -41,14 +41,14 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
     private $customObject;
 
     /**
-     * @var CustomItem
+     * @var array<CustomItem>
      */
-    private $customItem;
+    private $customItems;
 
     /**
-     * @var CustomFieldValueInterface
+     * @var array<CustomFieldValueInterface>
      */
-    private $textValue;
+    private $customFieldValues;
 
     protected function setUp(): void
     {
@@ -57,67 +57,113 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
         $this->customItemModel       = self::$container->get('mautic.custom.model.item');
         $this->customFieldValueModel = self::$container->get('mautic.custom.model.field.value');
 
-        $this->customObject = $this->createCustomObjectWithAllFields(self::$container, 'Car');
-        $this->customItem   = new CustomItem($this->customObject);
+        $this->customObject           = $this->createCustomObjectWithAllFields(self::$container, 'Car');
+        $this->customItems['nexon']   = new CustomItem($this->customObject);
 
-        $this->customItem->setName('Nexon');
-        $this->customFieldValueModel->createValuesForItem($this->customItem);
+        $this->customItems['nexon']->setName('Nexon');
+        $this->customFieldValueModel->createValuesForItem($this->customItems['nexon']);
 
-        $this->textValue       = $this->customItem->findCustomFieldValueForFieldAlias('text-test-field');
-        $this->textValue->setValue('Tata');
+        $this->customFieldValues['nexon-text']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('text-test-field');
+        $this->customFieldValues['nexon-text']->setValue('Tata');
 
-        $this->customItem = $this->customItemModel->save($this->customItem);
+        $this->customFieldValues['nexon-datetime']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('datetime-test-field');
+        $this->customFieldValues['nexon-datetime']->setValue('2024-07-01 13:29:43');
+
+        $this->customFieldValues['nexon-multiselect']       = $this->customItems['nexon']->findCustomFieldValueForFieldAlias('multiselect-test-field');
+        $this->customFieldValues['nexon-multiselect']->setValue('option_a');
+        $this->customFieldValues['nexon-multiselect']->setValue('option_b');
+
+        $this->customItems['nexon'] = $this->customItemModel->save($this->customItems['nexon']);
+
+        $this->customItems['fortuner']   = new CustomItem($this->customObject);
+
+        $this->customItems['fortuner']->setName('Fortuner');
+        $this->customFieldValueModel->createValuesForItem($this->customItems['fortuner']);
+
+        $this->customFieldValues['fortuner-text']       = $this->customItems['fortuner']->findCustomFieldValueForFieldAlias('text-test-field');
+        $this->customFieldValues['fortuner-text']->setValue('Toyota');
+
+        $this->customItems['fortuner'] = $this->customItemModel->save($this->customItems['fortuner']);
+
+        $this->customItems['city']   = new CustomItem($this->customObject);
+
+        $this->customItems['city']->setName('City');
+        $this->customFieldValueModel->createValuesForItem($this->customItems['city']);
+
+        $this->customFieldValues['city-text']       = $this->customItems['city']->findCustomFieldValueForFieldAlias('text-test-field');
+        $this->customFieldValues['city-text']->setValue('Honda');
+
+        $this->customItems['city'] = $this->customItemModel->save($this->customItems['city']);
     }
 
     public function testDynamicContentEmail(): void
     {
         foreach ([
+             [
+                 'nexonmultiselect@acquia.com',
+                 $this->buildDynamicContentArray([
+                     ['nexon-text', 'Tata', '='],
+                     ['nexon-datetime', '2024-07-01', 'gte'],
+                     ['nexon-multiselect', '"Option A"', 'in'],
+                 ]),
+                 'Custom Object Dynamic Content',
+             ],
             [
                 'nexonequal@acquia.com',
-                $this->buildDynamicContentArray('Tata', '='),
-                'Nexon Dynamic Content',
+                $this->buildDynamicContentArray([
+                    ['nexon-text', 'Tata', '='],
+                ]),
+                'Custom Object Dynamic Content',
             ], [
                 'nexonnotequal@acquia.com',
-                $this->buildDynamicContentArray('Toyota', '!='),
-                'Nexon Dynamic Content',
+                $this->buildDynamicContentArray([['nexon-text', 'Toyota', '!=']]),
+                'Custom Object Dynamic Content',
             ], [
                 'nexonempty@acquia.com',
-                $this->buildDynamicContentArray('', 'empty'),
+                $this->buildDynamicContentArray([['nexon-text', '', 'empty']]),
                 'Default Dynamic Content',
             ], [
                 'nexonnotempty@acquia.com',
-                $this->buildDynamicContentArray('', '!empty'),
-                'Nexon Dynamic Content',
+                $this->buildDynamicContentArray([['nexon-text', '', '!empty']]),
+                'Custom Object Dynamic Content',
             ], [
                 'nexonlike@acquia.com',
-                $this->buildDynamicContentArray('at', 'like'),
-                'Nexon Dynamic Content',
+                $this->buildDynamicContentArray([['nexon-text', 'at', 'like']]),
+                'Custom Object Dynamic Content',
             ], [
                 'nexonnotlike@acquia.com',
-                $this->buildDynamicContentArray('Toyota', '!like'),
-                'Nexon Dynamic Content',
+                $this->buildDynamicContentArray([['nexon-text', 'Toyota', '!like']]),
+                'Custom Object Dynamic Content',
             ], [
                 'nexonstartsWith@acquia.com',
-                $this->buildDynamicContentArray('Ta', 'startsWith'),
-                'Nexon Dynamic Content',
+                $this->buildDynamicContentArray([['nexon-text', 'Ta', 'startsWith']]),
+                'Custom Object Dynamic Content',
             ], [
                 'nexonendsWith@acquia.com',
-                $this->buildDynamicContentArray('ta', 'endsWith'),
-                'Nexon Dynamic Content',
+                $this->buildDynamicContentArray([['nexon-text', 'ta', 'endsWith']]),
+                'Custom Object Dynamic Content',
             ], [
                  'nexonendsWith@acquia.com',
-                 $this->buildDynamicContentArray('at', 'contains'),
-                 'Nexon Dynamic Content',
-             ],
+                 $this->buildDynamicContentArray([['nexon-text', 'at', 'contains']]),
+                 'Custom Object Dynamic Content',
+             ], [
+                'nexondatetime@acquia.com',
+                $this->buildDynamicContentArray([
+                    ['nexon-text', 'Tata', '='],
+                    ['nexon-datetime', '2024-07-01', 'gte'],
+                ]),
+                'Custom Object Dynamic Content',
+            ],
         ] as $item) {
             $this->emailWithCustomObjectDynamicContent($item[0], $item[1], $item[2]);
         }
     }
 
     /**
+     * @param array<mixed> $inputs
      * @return array<mixed>
      */
-    private function buildDynamicContentArray(string $filter, string $operator): array
+    private function buildDynamicContentArray(array $inputs): array
     {
         return [
             [
@@ -136,27 +182,18 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
                 'content'   => 'Default Dynamic Content',
                 'filters'   => [
                     [
-                        'content' => 'Nexon Dynamic Content',
-                        'filters' => [
-                            [
-                                'glue'     => 'and',
-                                'field'    => 'cmf_'.$this->textValue->getCustomField()->getId(),
-                                'object'   => 'custom_object',
-                                'type'     => 'text',
-                                'filter'   => $filter,
-                                'display'  => $this->customObject->getAlias().': text-test-field',
-                                'operator' => $operator,
-                            ],
-                            [
-                                'glue'     => 'and',
-                                'field'    => 'cmo_'.$this->customObject->getId(),
-                                'object'   => 'custom_object',
-                                'type'     => 'text',
-                                'filter'   => 'Nexon',
-                                'display'  => $this->customObject->getAlias(),
-                                'operator' => '=',
-                            ],
-                        ],
+                        'content' => 'Custom Object Dynamic Content',
+                        'filters' => array_map(function ($input) {
+                                return [
+                                    'glue'     => 'and',
+                                    'field'    => 'cmf_'.$this->customFieldValues[$input[0]]->getCustomField()->getId(),
+                                    'object'   => 'custom_object',
+                                    'type'     => 'text',
+                                    'filter'   => $input[1],
+                                    'display'  => $this->customObject->getName().':'.$this->customFieldValues[$input[0]]->getCustomField()->getLabel(),
+                                    'operator' => $input[2],
+                                ];
+                            }, $inputs),
                     ],
                 ],
             ],
@@ -174,7 +211,9 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
         $this->em->persist($email);
         $this->em->flush();
 
-        $this->customItemModel->linkEntity($this->customItem, 'contact', (int) $lead->getId());
+        $this->customItemModel->linkEntity($this->customItems['nexon'], 'contact', (int) $lead->getId());
+        $this->customItemModel->linkEntity($this->customItems['fortuner'], 'contact', (int) $lead->getId());
+        $this->customItemModel->linkEntity($this->customItems['city'], 'contact', (int) $lead->getId());
 
         $this->sendAndAssetText($email, $lead, $assertText);
     }
@@ -202,7 +241,7 @@ class EmailWithCustomObjectDynamicContentFunctionalTest extends MauticMysqlTestC
         return $lead;
     }
 
-    public function sendAndAssetText(Email $email, Lead $lead, string $matchText): void
+    private function sendAndAssetText(Email $email, Lead $lead, string $matchText): void
     {
         /** @var EmailModel $emailModel */
         $emailModel = self::$container->get('mautic.email.model.email');

--- a/Tests/Unit/EventListener/TokenSubscriberTest.php
+++ b/Tests/Unit/EventListener/TokenSubscriberTest.php
@@ -143,6 +143,7 @@ class TokenSubscriberTest extends TestCase
                 EmailEvents::EMAIL_ON_SEND                       => ['decodeTokens', 0],
                 EmailEvents::EMAIL_ON_DISPLAY                    => ['decodeTokens', 0],
                 CustomItemEvents::ON_CUSTOM_ITEM_LIST_DBAL_QUERY => ['onListQuery', -1],
+                EmailEvents::TOKEN_REPLACEMENT                   => ['onTokenReplacement', 100],
             ],
             TokenSubscriber::getSubscribedEvents()
         );

--- a/Tests/Unit/EventListener/TokenSubscriberTest.php
+++ b/Tests/Unit/EventListener/TokenSubscriberTest.php
@@ -29,6 +29,7 @@ use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
 use MauticPlugin\CustomObjectsBundle\Helper\TokenFormatter;
 use MauticPlugin\CustomObjectsBundle\Helper\TokenParser;
+use MauticPlugin\CustomObjectsBundle\Model\CustomFieldModel;
 use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
 use MauticPlugin\CustomObjectsBundle\Model\CustomObjectModel;
 use MauticPlugin\CustomObjectsBundle\Provider\ConfigProvider;
@@ -64,6 +65,11 @@ class TokenSubscriberTest extends TestCase
      * @var CustomItemModel|MockObject
      */
     private $customItemModel;
+
+    /**
+     * @var CustomFieldModel|MockObject
+     */
+    private $customFieldModel;
 
     /**
      * @var TokenParser|MockObject
@@ -114,6 +120,7 @@ class TokenSubscriberTest extends TestCase
         $this->queryFilterFactory = $this->createMock(QueryFilterFactory::class);
         $this->customObjectModel  = $this->createMock(CustomObjectModel::class);
         $this->customItemModel    = $this->createMock(CustomItemModel::class);
+        $this->customFieldModel   = $this->createMock(CustomFieldModel::class);
         $this->tokenParser        = $this->createMock(TokenParser::class);
         $this->eventModel         = $this->createMock(EventModel::class);
         $this->eventDispatcher    = $this->createMock(EventDispatcher::class);
@@ -124,6 +131,7 @@ class TokenSubscriberTest extends TestCase
             $this->queryFilterFactory,
             $this->customObjectModel,
             $this->customItemModel,
+            $this->customFieldModel,
             $this->tokenParser,
             $this->eventModel,
             $this->eventDispatcher,

--- a/Tests/Unit/EventListener/TokenSubscriberTest.php
+++ b/Tests/Unit/EventListener/TokenSubscriberTest.php
@@ -853,6 +853,7 @@ class TokenSubscriberTest extends TestCase
             $this->queryFilterFactory,
             $this->customObjectModel,
             $this->customItemModel,
+            $this->customFieldModel,
             $this->tokenParser,
             $this->eventModel,
             $this->eventDispatcher,

--- a/Tests/Unit/EventListener/TokenSubscriberTest.php
+++ b/Tests/Unit/EventListener/TokenSubscriberTest.php
@@ -135,7 +135,8 @@ class TokenSubscriberTest extends TestCase
             $this->tokenParser,
             $this->eventModel,
             $this->eventDispatcher,
-            $this->tokenFormatter
+            $this->tokenFormatter,
+            15
         );
 
         $this->builderEvent                 = $this->createMock(BuilderEvent::class);
@@ -857,7 +858,8 @@ class TokenSubscriberTest extends TestCase
             $this->tokenParser,
             $this->eventModel,
             $this->eventDispatcher,
-            new TokenFormatter()
+            new TokenFormatter(),
+            15
         );
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y]
| New feature/enhancement? (use the a.x branch)      | [ N]
| Deprecations?                          | [ N]
| BC breaks? (use the c.x branch)        | [N ]
| Automated tests included?              | [ Y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-11460

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Dynamic content in email builder filtered on custom object values
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

Create a segment email with dynamic content with one or more variations.
The variations should be based on the filters of Custom Object. 
Then, trigger/preview the email to the selected contacts that fall under the configured variations.
Users should receive dynamic content depending on Custom Object filter

#### Other areas of Mautic that may be affected by the change:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1.
2. 
