### PR TITLE
Hide the new operators from campaign condition, leave them for segment filters

### DIFF
--- a/CustomFieldType/DateOperatorTrait.php
+++ b/CustomFieldType/DateOperatorTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\CustomFieldType;
+
+trait DateOperatorTrait
+{
+    /**
+     * Remove operators that are supported only by segment filters.
+     *
+     * @return string[]
+     */
+    public function getOperatorOptions(): array
+    {
+        $options = parent::getOperatorOptions();
+
+        unset($options['between'], $options['!between'], $options['inLast'], $options['inNext']);
+
+        return $options;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getOperators(): array
+    {
+        $allOperators     = parent::getOperators();
+        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty', 'between', '!between', 'inLast', 'inNext']);
+
+        return array_intersect_key($allOperators, $allowedOperators);
+    }
+}

--- a/CustomFieldType/DateTimeType.php
+++ b/CustomFieldType/DateTimeType.php
@@ -17,6 +17,8 @@ use Symfony\Component\Form\DataTransformerInterface;
 
 class DateTimeType extends AbstractCustomFieldType
 {
+    use DateOperatorTrait;
+
     /**
      * @var string
      */
@@ -68,17 +70,6 @@ class DateTimeType extends AbstractCustomFieldType
     public function getEntityClass(): string
     {
         return CustomFieldValueDateTime::class;
-    }
-
-    /**
-     * @return mixed[]
-     */
-    public function getOperators(): array
-    {
-        $allOperators     = parent::getOperators();
-        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty', 'between', '!between', 'inLast', 'inNext']);
-
-        return array_intersect_key($allOperators, $allowedOperators);
     }
 
     /**

--- a/CustomFieldType/DateType.php
+++ b/CustomFieldType/DateType.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\DataTransformerInterface;
 
 class DateType extends AbstractCustomFieldType
 {
+    use DateOperatorTrait;
+
     /**
      * @var string
      */
@@ -68,17 +70,6 @@ class DateType extends AbstractCustomFieldType
     public function getEntityClass(): string
     {
         return CustomFieldValueDate::class;
-    }
-
-    /**
-     * @return mixed[]
-     */
-    public function getOperators(): array
-    {
-        $allOperators     = parent::getOperators();
-        $allowedOperators = array_flip(['=', '!=', 'gt', 'gte', 'lt', 'lte', 'empty', '!empty', 'between', '!between', 'inLast', 'inNext']);
-
-        return array_intersect_key($allOperators, $allowedOperators);
     }
 
     /**

--- a/CustomFieldType/IntType.php
+++ b/CustomFieldType/IntType.php
@@ -42,6 +42,20 @@ class IntType extends AbstractCustomFieldType
     }
 
     /**
+     * Remove operators that are supported only by segment filters.
+     *
+     * @return string[]
+     */
+    public function getOperatorOptions(): array
+    {
+        $options = parent::getOperatorOptions();
+
+        unset($options['between'], $options['!between']);
+
+        return $options;
+    }
+
+    /**
      * @return mixed[]
      */
     public function getOperators(): array


### PR DESCRIPTION


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes [MAUT-11602](https://acquia.atlassian.net/browse/MAUT-11602)

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR fixes https://github.com/acquia/mc-cs-plugin-custom-objects/pull/348, https://github.com/acquia/mc-cs-plugin-custom-objects/pull/347 and https://github.com/acquia/mc-cs-plugin-custom-objects/pull/346 that added new operators to segment filters but they unintentionally also added them to the campaign condition form. They aren't implemented there. So this PR is hiding them from campaign condition form.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Check that the between, in the last and in the next operators are visible for custom object segment filters based on date fields, but not in the campaign conditions
3. Same for the between operator on the numeric fields.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->