### PR TITLE
MAUT-8476: Integer in label for option error fix 

### DIFF
--- a/Entity/CustomField.php
+++ b/Entity/CustomField.php
@@ -578,7 +578,7 @@ class CustomField extends FormEntity implements UniqueEntityInterface, UuidInter
             throw new NotFoundException("Label was not found for value {$value}");
         }
 
-        return $label;
+        return (string) $label;
     }
 
     /**

--- a/Tests/Unit/Entity/CustomFieldTest.php
+++ b/Tests/Unit/Entity/CustomFieldTest.php
@@ -316,6 +316,22 @@ class CustomFieldTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Option B', $customField->valueToLabel('option_b'));
     }
 
+    public function testValueToLabelWithInteger(): void
+    {
+        $customField = new CustomField();
+        $optionB     = new CustomFieldOption();
+        $optionB->setLabel('1');
+        $optionB->setValue('1');
+        $customField->addOption($optionB);
+        $customField->setTypeObject(
+            new SelectType(
+                $this->createMock(TranslatorInterface::class),
+                $this->createMock(FilterOperatorProviderInterface::class)
+            )
+        );
+        $this->assertSame('1', $customField->valueToLabel('1'));
+    }
+
     public function testValueToLabelIfOptionNotFound(): void
     {
         $customField = new CustomField();


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y ]
| New feature/enhancement? (use the a.x branch)      | [ N]
| Deprecations?                          | [ N]
| BC breaks? (use the c.x branch)        | [ N]
| Automated tests included?              | [ Y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-8476

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Integer in label for options fails to load in valueToLabel method since it is set to return string, but we are sending integer, therefore the problem is.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
Create custom object with 2-3 select fields having some options having string label and value with integer.

Try to create custom item for the custom object and use "Save and Close" button to save an item.

Observe that there was no issue and the custom item was successfully saved.