### PR TITLE
MAUT-11616 : Fix operators do not refresh after selecting a different type of field in campaign event

### DIFF
--- a/Form/Type/CampaignConditionFieldValueType.php
+++ b/Form/Type/CampaignConditionFieldValueType.php
@@ -52,6 +52,20 @@ class CampaignConditionFieldValueType extends AbstractType
             $choices[$field->getLabel()] = $field->getId();
         }
 
+        $optionAttr = array_combine(
+            array_map(fn($field) => $field->getLabel(), $fields),
+            array_map(
+                function ($field) {
+                    return [
+                        'data-operators' => json_encode($field->getTypeObject()->getOperatorOptions()),
+                        'data-options' => json_encode($field->getChoices()),
+                        'data-field-type' => $field->getType(),
+                    ];
+                },
+                $fields
+            )
+        );
+
         $builder->add(
             'field',
             ChoiceType::class,
@@ -62,16 +76,7 @@ class CampaignConditionFieldValueType extends AbstractType
                 'attr'     => [
                     'class' => 'form-control',
                 ],
-                'choice_attr' => array_map(
-                    function ($field) {
-                        return [
-                        'data-operators'  => json_encode($field->getTypeObject()->getOperatorOptions()),
-                        'data-options'    => json_encode($field->getChoices()),
-                        'data-field-type' => $field->getType(),
-                    ];
-                    },
-                    $fields
-                ),
+                'choice_attr' => $optionAttr,
             ]
         );
 

--- a/Form/Type/CampaignConditionFieldValueType.php
+++ b/Form/Type/CampaignConditionFieldValueType.php
@@ -53,12 +53,12 @@ class CampaignConditionFieldValueType extends AbstractType
         }
 
         $optionAttr = array_combine(
-            array_map(fn($field) => $field->getLabel(), $fields),
+            array_map(fn ($field) => $field->getLabel(), $fields),
             array_map(
                 function ($field) {
                     return [
-                        'data-operators' => json_encode($field->getTypeObject()->getOperatorOptions()),
-                        'data-options' => json_encode($field->getChoices()),
+                        'data-operators'  => json_encode($field->getTypeObject()->getOperatorOptions()),
+                        'data-options'    => json_encode($field->getChoices()),
                         'data-field-type' => $field->getType(),
                     ];
                 },

--- a/Form/Type/CampaignConditionFieldValueType.php
+++ b/Form/Type/CampaignConditionFieldValueType.php
@@ -46,25 +46,18 @@ class CampaignConditionFieldValueType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $fields  = $this->customFieldModel->fetchCustomFieldsForObject($options['customObject']);
-        $choices = [];
-        foreach ($fields as $field) {
-            $choices[$field->getLabel()] = $field->getId();
-        }
+        $fields     = $this->customFieldModel->fetchCustomFieldsForObject($options['customObject']);
+        $choices    = [];
+        $optionAttr = [];
 
-        $optionAttr = array_combine(
-            array_map(fn ($field) => $field->getLabel(), $fields),
-            array_map(
-                function ($field) {
-                    return [
-                        'data-operators'  => json_encode($field->getTypeObject()->getOperatorOptions()),
-                        'data-options'    => json_encode($field->getChoices()),
-                        'data-field-type' => $field->getType(),
-                    ];
-                },
-                $fields
-            )
-        );
+        foreach ($fields as $field) {
+            $choices[$field->getLabel()]    = $field->getId();
+            $optionAttr[$field->getLabel()] = [
+                'data-operators'  => json_encode($field->getTypeObject()->getOperatorOptions()),
+                'data-options'    => json_encode($field->getChoices()),
+                'data-field-type' => $field->getType(),
+            ];
+        }
 
         $builder->add(
             'field',

--- a/Tests/Functional/EventListener/CampaignConditionTest.php
+++ b/Tests/Functional/EventListener/CampaignConditionTest.php
@@ -67,4 +67,34 @@ class CampaignConditionTest extends MauticMysqlTestCase
         Assert::assertSame('=', $body['event']['properties']['properties']['operator']);
         Assert::assertSame('unicorn', $body['event']['properties']['properties']['value']);
     }
+
+    public function testVerifyDataOperatorAttrIsAvailableForFields(): void
+    {
+        $customObject = $this->createCustomObjectWithAllFields(self::$container, 'Campaign test object');
+        $crawler      = $this->client->request(
+            Request::METHOD_GET,
+            's/campaigns/events/new',
+            [
+                'campaignId'      => 'mautic_041b2a401f680fb0b644654af5ba0892f31f0697',
+                'type'            => "custom_item.{$customObject->getId()}.fieldvalue",
+                'eventType'       => 'condition',
+                'anchor'          => 'leadsource',
+                'anchorEventType' => 'source',
+            ],
+            [],
+            $this->createAjaxHeaders()
+        );
+
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+
+        $html = json_decode($this->client->getResponse()->getContent(), true)['newContent'];
+
+        $crawler->addHtmlContent($html);
+
+        $options = $crawler->filter('#campaignevent_properties_field')->filter('option'); // ->attr('data-operators');
+
+        foreach ($options as $option) {
+            Assert::assertNotEmpty($option->getAttribute('data-operators'));
+        }
+    }
 }

--- a/Tests/Functional/EventListener/CampaignConditionTest.php
+++ b/Tests/Functional/EventListener/CampaignConditionTest.php
@@ -93,6 +93,7 @@ class CampaignConditionTest extends MauticMysqlTestCase
 
         $options = $crawler->filter('#campaignevent_properties_field')->filter('option'); // ->attr('data-operators');
 
+        /** @var \DOMElement $option */
         foreach ($options as $option) {
             Assert::assertNotEmpty($option->getAttribute('data-operators'));
         }

--- a/Tests/Unit/Form/Type/CampaignConditionFieldValueTypeTest.php
+++ b/Tests/Unit/Form/Type/CampaignConditionFieldValueTypeTest.php
@@ -102,7 +102,7 @@ final class CampaignConditionFieldValueTypeTest extends TestCase
                             'class' => 'form-control',
                         ],
                         'choice_attr' => [
-                            42 => [
+                            'Cheese' => [
                                 'data-operators'  => '{"=":"a","!=":"b"}',
                                 'data-options'    => '[]',
                                 'data-field-type' => 'int',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-11616 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Campaign →  Condition →  Custom Object field values : Operators do not refresh after selecting a different type of field.

In the custom objects, the operators related to the Top most field of Custom objects get loaded when we open this form. Upon changing the field, the operators do not refresh/update as we see in Campaign → condition → Contact Field values form.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Campaign builder and select Condition → Custom Object field values
3. Verify that on change field value operator should be change as per the field type.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->