### PR TITLE
MAUT-11383 : incorrect date value being calculating when the segment filter value is "yesterday" and operator is "gt" for date field

### DIFF
--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -86,6 +86,7 @@ class QueryFilterHelper
         ContactSegmentFilter $filter,
         bool $filterAlreadyNegated = false
     ): void {
+        $filterValue = $filter->getParameterValue();
         foreach ($unionQueryContainer as $segmentQueryBuilder) {
             $valueParameter = $this->randomParameterNameService->generateRandomParameterName();
             $expression     = $this->getCustomValueValueExpression(
@@ -94,14 +95,14 @@ class QueryFilterHelper
                 $filter,
                 $valueParameter,
                 $filterAlreadyNegated,
-                $filter->getParameterValue()
+                $filterValue
             );
 
             $this->addOperatorExpression(
                 $segmentQueryBuilder,
                 $expression,
                 $filter->getOperator(),
-                $filter->getParameterValue(),
+                $filterValue,
                 $valueParameter
             );
         }

--- a/Tests/Functional/Helper/QueryFilterHelperTest.php
+++ b/Tests/Functional/Helper/QueryFilterHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\Helper;
 
+use DateTime;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterFactory;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
@@ -244,9 +245,27 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
                 ],
             ]
         );
+
+        $this->assertMatchWhere(
+            'test_value.value >= :pard',
+            [
+                'glue'       => 'and',
+                'field'      => 'cmf_'.$this->getFixtureById('custom_object_product')->getId(),
+                'object'     => 'custom_object',
+                'type'       => 'date',
+                'operator'   => 'gte',
+                'properties' => [
+                    'filter' => [
+                        'dateTypeMode' => 'absolute',
+                        'absoluteDate' => 'yesterday',
+                    ],
+                ],
+            ],
+            (new DateTime('yesterday'))->format('Y-m-d')
+        );
     }
 
-    protected function assertMatchWhere(string $expectedWhere, array $filter): void
+    protected function assertMatchWhere(string $expectedWhere, array $filter, ?string $expectedValue = null): void
     {
         $unionQueryContainer = new UnionQueryContainer();
         $qb                  = new QueryBuilder($this->em->getConnection());
@@ -259,7 +278,12 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
         );
 
         $unionQueryContainer->rewind();
+
         $whereResponse = (string) $unionQueryContainer->current()->getQueryPart('where');
+
         $this->assertSame($expectedWhere, $whereResponse);
+        if ($expectedValue) {
+            $this->assertSame($expectedValue, current($unionQueryContainer->current()->getParameters()));
+        }
     }
 }

--- a/Tests/Functional/Helper/QueryFilterHelperTest.php
+++ b/Tests/Functional/Helper/QueryFilterHelperTest.php
@@ -263,6 +263,24 @@ class QueryFilterHelperTest extends MauticMysqlTestCase
             ],
             (new DateTime('yesterday'))->format('Y-m-d')
         );
+
+        $this->assertMatchWhere(
+            'test_value.value <= :pare',
+            [
+                'glue'       => 'and',
+                'field'      => 'cmf_'.$this->getFixtureById('custom_object_product')->getId(),
+                'object'     => 'custom_object',
+                'type'       => 'datetime',
+                'operator'   => 'lte',
+                'properties' => [
+                    'filter' => [
+                        'dateTypeMode' => 'absolute',
+                        'absoluteDate' => 'tomorrow',
+                    ],
+                ],
+            ],
+            (new DateTime('tomorrow'))->format('Y-m-d 23:59:59')
+        );
     }
 
     protected function assertMatchWhere(string $expectedWhere, array $filter, ?string $expectedValue = null): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://acquia.atlassian.net/browse/MAUT-11383 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
For custom object date and date time for yesterday it is taking -2 day date and for tomorrow it is taking +2 day date.
For eg: today is 26:

for after inc day yesterday it shows: >= '2024-09-24' 

for before inc day tomorrow it shows: <= '2024-09-28 23:59:59'

adding one day xtra in value
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom object with datetime field
3. Create segment filter with after including day or before including day with value yesterday or tomorrow
4. Filter should work correctly

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->