### PR TITLE
Added API endpoint to delete and unlink custom items

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
     #     verbose: true
 
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mautic-logs
         path: var/logs/

--- a/Config/config.php
+++ b/Config/config.php
@@ -185,6 +185,25 @@ $coParams = [
                 'method'     => 'GET|POST',
             ],
         ],
+        'api' => [
+            'mautic_api_custom_item_unlink' => [
+                'path'         => '/custom/item/{itemId}/unlink/{contactId}',
+                'controller'   => 'CustomObjectsBundle:CustomItem\Api\Custom:unlink',
+                'method'       => 'DELETE',
+                'requirements' => [
+                    'itemId'    => '\d+',
+                    'contactId' => '\d+',
+                ],
+            ],
+            'mautic_api_custom_item_delete' => [
+                'path'         => '/custom/item/{itemId}/delete',
+                'controller'   => 'CustomObjectsBundle:CustomItem\Api\Custom:delete',
+                'method'       => 'DELETE',
+                'requirements' => [
+                    'itemId'    => '\d+',
+                ],
+            ],
+        ],
     ],
 
     'services' => [
@@ -405,6 +424,20 @@ $coParams = [
                 'arguments' => [
                     'custom_item.permission.provider',
                     'mautic.custom.model.export_scheduler',
+                ],
+            ],
+
+            'custom_item.api_custom_controller' => [
+                'class'     => \MauticPlugin\CustomObjectsBundle\Controller\CustomItem\Api\CustomController::class,
+                'arguments' => [
+                    'mautic.custom.model.item',
+                    'custom_item.permission.provider',
+                    'translator',
+                ],
+                'methodCalls' => [
+                    'setContainer' => [
+                        '@service_container',
+                    ],
                 ],
             ],
 

--- a/Controller/CustomItem/Api/CustomController.php
+++ b/Controller/CustomItem/Api/CustomController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Controller\CustomItem\Api;
+
+use MauticPlugin\CustomObjectsBundle\Controller\JsonController;
+use MauticPlugin\CustomObjectsBundle\Exception\ForbiddenException;
+use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
+use MauticPlugin\CustomObjectsBundle\Model\CustomItemModel;
+use MauticPlugin\CustomObjectsBundle\Provider\CustomItemPermissionProvider;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomController extends JsonController
+{
+    private CustomItemModel $customItemModel;
+    private CustomItemPermissionProvider $permissionProvider;
+
+    public function __construct(
+        CustomItemModel $customItemModel,
+        CustomItemPermissionProvider $permissionProvider
+    ) {
+
+        $this->customItemModel = $customItemModel;
+        $this->permissionProvider = $permissionProvider;
+    }
+
+    public function unlinkAction(int $itemId, int $contactId): JsonResponse
+    {
+        try {
+            $customItem = $this->customItemModel->fetchEntity($itemId);
+
+            $this->permissionProvider->canEdit($customItem);
+
+            if ($customItem->getCustomObject()->getRelationshipObject()) {
+                try {
+                    $childCustomItem = $customItem->findChildCustomItem();
+                } catch (NotFoundException $e) {
+                }
+
+                if (isset($childCustomItem)) {
+                    $this->customItemModel->delete($childCustomItem);
+                }
+            }
+
+            $this->customItemModel->unlinkEntity($customItem, 'contact', $contactId);
+
+            return new JsonResponse(['success' => true]);
+
+        } catch (ForbiddenException|NotFoundException|\UnexpectedValueException $e) {
+            return new JsonResponse([
+                'message' => $e->getMessage(),
+                'success' => false,
+            ], $e->getCode());
+        }
+    }
+
+    public function deleteAction(int $itemId): Response
+    {
+        try {
+            $customItem = $this->customItemModel->fetchEntity($itemId);
+            $this->permissionProvider->canDelete($customItem);
+        } catch (NotFoundException|ForbiddenException $e) {
+            return new JsonResponse([
+                'message' => $e->getMessage(),
+                'success' => false,
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        $this->customItemModel->delete($customItem);
+
+        return new JsonResponse(['success' => true]);
+    }
+}

--- a/Tests/Functional/CustomApiControllerTest.php
+++ b/Tests/Functional/CustomApiControllerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Functional;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomItem;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomItemXrefContact;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
+use MauticPlugin\CustomObjectsBundle\Repository\CustomItemRepository;
+use MauticPlugin\CustomObjectsBundle\Repository\CustomItemXrefContactRepository;
+
+final class CustomApiControllerTest extends MauticMysqlTestCase
+{
+    private ?CustomItemRepository $customItemRepository;
+    private ?CustomItemXrefContactRepository $customItemXrefContactRepository;
+    private Lead $contact;
+    private CustomItem $customItem;
+
+    protected function setUp(): void
+    {
+        $this->configParams['custom_objects_enabled'] = true;
+
+        parent::setUp();
+
+        $this->customItemRepository             = self::$container->get('custom_item.repository');
+        $this->customItemXrefContactRepository  = self::$container->get('custom_item.xref.contact.repository');
+
+        // Create a Contact
+        $this->contact = $this->createContact();
+        // Create a Custom Object
+        $customObject = $this->createCustomObject('Product', 'Products');
+        // Create a Custom Item
+        $this->customItem = $this->createCustomItem($customObject, 'Product 1');
+        // Relate CI with Contact
+        $this->createCustomItemXrefContact($this->customItem, $this->contact);
+    }
+
+    public function testDetachCustomItemFomContact(): void
+    {
+        $items = $this->customItemRepository->count([]);
+        $links = $this->customItemXrefContactRepository->count([]);
+        $this->assertEquals(1, $items);
+        $this->assertEquals(1, $links);
+
+        $this->client->request('DELETE', sprintf('/api/custom/item/%s/unlink/%s', $this->customItem->getId(), $this->contact->getId()));
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $items = $this->customItemRepository->count([]);
+        $links = $this->customItemXrefContactRepository->count([]);
+        $this->assertEquals(1, $items);
+        $this->assertEquals(0, $links);
+    }
+
+    public function testDeleteCustomItem(): void
+    {
+        $items = $this->customItemRepository->count([]);
+        $links = $this->customItemXrefContactRepository->count([]);
+        $this->assertEquals(1, $items);
+        $this->assertEquals(1, $links);
+
+        $this->client->request('DELETE', sprintf('/api/custom/item/%s/delete', $this->customItem->getId()));
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $items = $this->customItemRepository->count([]);
+        $links = $this->customItemXrefContactRepository->count([]);
+        $this->assertEquals(0, $items);
+        $this->assertEquals(0, $links);
+    }
+
+    private function createCustomObject(string $singular, string $plural): CustomObject
+    {
+        $customObject = new CustomObject();
+        $customObject->setNameSingular($singular);
+        $customObject->setNamePlural($plural);
+        $customObject->setAlias(mb_strtolower($plural));
+        $this->em->persist($customObject);
+        $this->em->flush();
+
+        return $customObject;
+    }
+
+    private function createContact(): Lead
+    {
+        $lead = new Lead();
+        $this->em->persist($lead);
+        $this->em->flush();
+
+        return $lead;
+    }
+
+    private function createCustomItem(CustomObject $customObject, string $name): CustomItem
+    {
+        $customItem = new CustomItem($customObject);
+        $customItem->setName($name);
+        $this->em->persist($customItem);
+        $this->em->flush();
+
+        return $customItem;
+    }
+
+    private function createCustomItemXrefContact(CustomItem $customItem, Lead $contact): void
+    {
+        $customItemXrefContact = new CustomItemXrefContact($customItem, $contact);
+
+        $this->em->persist($customItemXrefContact);
+        $this->em->flush();
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Added following endpoints,

---


### Endpoint: Unlink Contact from Custom Item

**Request Type:** `DELETE`

**URL:** `/api/custom/item/{item-id}/unlink/{contact-id}`

**Description:**  
This endpoint removes the association between a custom item and a contact in Mautic.

#### Parameters:
- **item-id** (path parameter):  
  The unique identifier for the custom item from which the contact will be unlinked.

- **contact-id** (path parameter):  
  The unique identifier for the contact to be unlinked from the custom item.

#### Headers:
- **Authorization:**  
  Required for authentication. Use `Basic` authorization with your encoded credentials.

  ```plaintext
  Authorization: Basic <encoded_credentials>
  ```

#### Example Request:
```http
DELETE /api/custom/item/123/unlink/456 HTTP/1.1
Host: mautic.instace
Authorization: Basic YRasW90bWF1dTll
```


#### Response:
- **Success:**
    - **Status Code:** `200 OK`


- **Errors:**
    - **404 Not Found**: If either the `item-id` or `contact-id` does not exist.
    - **401 Unauthorized**: If authentication credentials are missing or invalid.

#### Example Response:
```json
{
  "success": true
}
```

---

### Endpoint: Delete Custom Item

**Request Type:** `DELETE`

**URL:** `/api/custom/item/{item-id}/delete`

**Description:**  
This endpoint permanently deletes a custom item from Mautic.

#### Parameters:
- **item-id** (path parameter):  
  The unique identifier of the custom item to be deleted.

#### Headers:
- **Authorization:**  
  Required for authentication. Use `Basic` authorization with your encoded credentials.

  ```plaintext
  Authorization: Basic <encoded_credentials>
  ```

#### Example Request:
```http
DELETE /api/custom/item/123/delete HTTP/1.1
Host: mautic.instace
Authorization: Basic YRasW90bWF1dTll
```


#### Response:
- **Success:**
  - **Status Code:** `200 OK`

- **Errors:**
  - **404 Not Found**: If either the `item-id` does not exist.
  - **401 Unauthorized**: If authentication credentials are missing or invalid.

#### Example Response:
```json
{
  "success": true
}
```
---

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->