### PR TITLE
MAUT-12306: Use the same value query when dealing with merged filters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
     #     verbose: true
 
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mautic-logs
         path: var/logs/

--- a/Segment/Query/Filter/QueryFilterFactory.php
+++ b/Segment/Query/Filter/QueryFilterFactory.php
@@ -48,7 +48,10 @@ class QueryFilterFactory
 
         $type = $segmentFilter->getQueryType();
 
-        if (CustomFieldFilterQueryBuilder::getServiceId() === $type) {
+        if (in_array($type, [
+            CustomFieldFilterQueryBuilder::getServiceId(),
+            CustomObjectMergedFilterQueryBuilder::getServiceId()
+        ])) {
             $queryBuilder = $this->queryFilterHelper->createValueQuery(
                 $queryAlias,
                 $segmentFilter

--- a/Segment/Query/Filter/QueryFilterFactory.php
+++ b/Segment/Query/Filter/QueryFilterFactory.php
@@ -50,7 +50,7 @@ class QueryFilterFactory
 
         if (in_array($type, [
             CustomFieldFilterQueryBuilder::getServiceId(),
-            CustomObjectMergedFilterQueryBuilder::getServiceId()
+            CustomObjectMergedFilterQueryBuilder::getServiceId(),
         ])) {
             $queryBuilder = $this->queryFilterHelper->createValueQuery(
                 $queryAlias,


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

We discovered an issue when replacing custom-object tokens within an email when that email was based on segments containing custom object filters. If the `custom_object_merge_filter` parameter is set to true and the `custom_object_item_value_to_contact_relation_limit` is set to 0, the most recently created custom object (of the specified type) is used when replacing the token.

The scenario is this:

- Create a custom object "Kids" with a Text field - Name,  Numeric field - Age
- Create 3-4 custom items from the above CO
- Link a contact with all these custom items
- Create a segment with filter on CO: Age Equals 6 (assuming you have an item with age = 6)
- Create a segment email, utilize the segment created in step 4
- In the email builder merge-tag, find and select the token for CO: Name ( a long token will get inserted in the builder - Do not modify anything in that)
- Save & Close the Email
- Go to Preview the email → Search the contact that you’ve linked the custom items with.
- Observe the output rendered. This output is not accurate and results in incorrect information being rendered.
- The output rendered will show the latest custom item attached to the contact rather than the custom item which matches the filter.

This PR ensures segment filters utilizing custom objects will behave similarly, regardless of whether the custom_object_merge_filter option is on or off (except for mandatory differences covered in other parts of the code untouched by this PR)

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Perform the steps outlined above and see that the correct custom item is used to render the output. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->