### PR TITLE
Revert "[BUGFIX] Add plugin-enabled check condition to CustomObjectPermissions…"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
     #     verbose: true
 
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mautic-logs
         path: var/logs/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,5 +141,9 @@ jobs:
     - name: Upload logs as artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: mautic-logs
+        name: mautic-logs-${{ matrix.php-versions }}-${{ github.run_id }}
         path: var/logs/
+        if-no-files-found: warn
+        compression-level: 6
+        overwrite: false
+        include-hidden-files: false

--- a/Config/config.php
+++ b/Config/config.php
@@ -1042,7 +1042,6 @@ $coParams = [
                 'class'     => ConfigProvider::class,
                 'arguments' => [
                     'mautic.helper.core_parameters',
-                    'database_connection',
                 ],
             ],
             'custom_field.type.provider' => [

--- a/Provider/ConfigProvider.php
+++ b/Provider/ConfigProvider.php
@@ -4,17 +4,13 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Provider;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
 
 class ConfigProvider
 {
     /**
      * @var string
      */
-    public const CONFIG_PLUGIN_NAME                                = 'CustomObjectsBundle';
     public const CONFIG_PARAM_ENABLED                              = 'custom_objects_enabled';
     public const CONFIG_PARAM_ITEM_VALUE_TO_CONTACT_RELATION_LIMIT = 'custom_object_item_value_to_contact_relation_limit';
 
@@ -25,15 +21,9 @@ class ConfigProvider
      */
     private $coreParametersHelper;
 
-    /**
-     * @var Connection
-     */
-    private $connection;
-
-    public function __construct(CoreParametersHelper $coreParametersHelper, Connection $connection)
+    public function __construct(CoreParametersHelper $coreParametersHelper)
     {
         $this->coreParametersHelper = $coreParametersHelper;
-        $this->connection           = $connection;
     }
 
     /**
@@ -41,22 +31,7 @@ class ConfigProvider
      */
     public function pluginIsEnabled(): bool
     {
-        $pluginEnabled = (bool) $this->coreParametersHelper->get(self::CONFIG_PARAM_ENABLED, true);
-        if (!$pluginEnabled) {
-            return false;
-        }
-
-        try {
-            $pluginWasInstalledBefore = $this->connection
-                ->executeQuery('SELECT id FROM plugins WHERE bundle=:pluginName', ['pluginName' => self::CONFIG_PLUGIN_NAME])
-                ->rowCount();
-            $customObjectsTableExists = $this->connection
-                ->executeQuery('SHOW TABLES LIKE :tableName', ['tableName' => CustomObject::TABLE_NAME])
-                ->rowCount();
-            return $pluginWasInstalledBefore && $customObjectsTableExists;
-        } catch (Exception $e) {
-            return false;
-        }
+        return (bool) $this->coreParametersHelper->get(self::CONFIG_PARAM_ENABLED, true);
     }
 
     public function isCustomObjectMergeFilterEnabled(): bool

--- a/Security/Permissions/CustomObjectPermissions.php
+++ b/Security/Permissions/CustomObjectPermissions.php
@@ -56,10 +56,6 @@ class CustomObjectPermissions extends AbstractPermissions
      */
     public function definePermissions(): void
     {
-        if (!$this->isEnabled()) {
-            return;
-        }
-
         $this->addExtendedPermissions(['custom_fields', self::NAME]);
 
         $customObjects = $this->getCustomObjects();


### PR DESCRIPTION
Reverts acquia/mc-cs-plugin-custom-objects#292 because it fails many tests when it got merged (https://github.com/acquia/mc-cs-plugin-custom-objects/actions/runs/13922605560/job/38959186483?pr=365)

I tried to fix the CI but there is too much to fix https://github.com/acquia/mc-cs-plugin-custom-objects/pull/365