### PR TITLE
feat: Improve contact merge to use database query instead of loading potentially many many items

### DIFF
--- a/Repository/CustomItemXrefContactRepository.php
+++ b/Repository/CustomItemXrefContactRepository.php
@@ -62,4 +62,32 @@ class CustomItemXrefContactRepository extends CustomCommonRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function mergeLead(Lead $victor, Lead $loser): void
+    {
+        // Move all custom item references to the victor lead, but only if the victor doesn't already have
+        // a reference to the custom item
+        $existingAlias = CustomItemXrefContact::TABLE_ALIAS.'_Check';
+
+        $this->createQueryBuilder(CustomItemXrefContact::TABLE_ALIAS)
+            ->update()
+            ->set(CustomItemXrefContact::TABLE_ALIAS.'.contact', ':victor')
+            ->where(CustomItemXrefContact::TABLE_ALIAS.'.contact = :loser')
+            ->andWhere(
+                $this->createQueryBuilder(CustomItemXrefContact::TABLE_ALIAS)
+                    ->expr()
+                    ->notIn(
+                        CustomItemXrefContact::TABLE_ALIAS.'.customItem',
+                        $this->createQueryBuilder($existingAlias)
+                            ->select('IDENTITY('.$existingAlias.'.customItem)')
+                            ->where($existingAlias.'.contact = :victor')
+                            ->getDQL()
+                    )
+            )
+            ->setParameter('victor', $victor->getId())
+            ->setParameter('loser', $loser->getId())
+            ->getQuery()
+            ->execute();
+
+    }
 }


### PR DESCRIPTION

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

Currently the contact item merge loads a huge amount of objects in some cases to migrate them to the new parent. It's better and faster to process as a query, similar to how all other merge operations are handled. It can process large amounts of items extremely quickly.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a contact with a unique email
3. Add many custom objects
4. Submit a new contact by API that is anonymous
5. Update that contact using the same email
6. Merge should work (might need run command line)
* I don't know if these steps will work - for me I was testing with our own merge function *

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->