### PR TITLE
Adding return types necessary for PHP 8.1 support

### DIFF
--- a/Entity/CustomFieldOption.php
+++ b/Entity/CustomFieldOption.php
@@ -164,7 +164,7 @@ class CustomFieldOption implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->{$offset});
     }
@@ -180,7 +180,7 @@ class CustomFieldOption implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->{$offset} = $value;
     }
@@ -188,7 +188,7 @@ class CustomFieldOption implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->{$offset} = null;
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://acquia.atlassian.net/browse/MAUT-12640

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

PHPSTAN is failing with
```
Line   plugins/CustomObjectsBundle/Entity/CustomFieldOption.php
--
  |   |   | ------ -----------------------------------------------------------------------
  |   |   | 167    Return type mixed of method
  |   |   | MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption::offsetExis
  |   |   | ts() is not covariant with tentative return type bool of method
  |   |   | ArrayAccess::offsetExists().
  |   |   | 💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute
  |   |   | to temporarily suppress the error.
  |   |   | 183    Return type mixed of method
  |   |   | MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption::offsetSet(
  |   |   | ) is not covariant with tentative return type void of method
  |   |   | ArrayAccess::offsetSet().
  |   |   | 💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute
  |   |   | to temporarily suppress the error.
  |   |   | 191    Return type mixed of method
  |   |   | MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption::offsetUnse
  |   |   | t() is not covariant with tentative return type void of method
  |   |   | ArrayAccess::offsetUnset().
  |   |   | 💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute
  |   |   | to temporarily suppress the error.
  |   |   | ------ -----------------------------------------------------------------------
```
on PHP 8.1. This PR addresses it.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Test creating a custom object with a (multi)select field.
2. Test that a custom item can be created and add some value(s).

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->