### PR TITLE
One more PHP 8.1 deprecation fix

### DIFF
--- a/Entity/CustomFieldOption.php
+++ b/Entity/CustomFieldOption.php
@@ -171,8 +171,12 @@ class CustomFieldOption implements \ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @param mixed $offset
+     *
+     * @return mixed
      */
-    public function offsetGet(mixed $offset): mixed
+    public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->{$offset} : null;
     }

--- a/Entity/CustomFieldOption.php
+++ b/Entity/CustomFieldOption.php
@@ -172,7 +172,7 @@ class CustomFieldOption implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->offsetExists($offset) ? $this->{$offset} : null;
     }


### PR DESCRIPTION

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR is fixing 

```
PHP Deprecated:  Return type of MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed
```
when running the plugin on PHP 8.1

Adding the `mixed type` directly to the code isn't possible as this CO version must also support PHP 7.4. So I had to go for annotations.


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Run `cd plugins/CustomObjects && composer install` on Mautic 4 with this plugin installed on PHP 8.1 to see the deprecation notice.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->