### PR TITLE
#11554: Fixed Operators issue for Custom object Segment filters.

### DIFF
--- a/Helper/QueryFilterFactory.php
+++ b/Helper/QueryFilterFactory.php
@@ -64,7 +64,7 @@ class QueryFilterFactory
     ): UnionQueryContainer {
         $segmentFilterFieldId   = (int) $segmentFilter->getField();
         $segmentFilterFieldType = $segmentFilter->getType();
-        if ('select' === $segmentFilterFieldType || null === $segmentFilterFieldType || '' === $segmentFilterFieldType) {
+        if (empty($segmentFilterFieldType) || '' === $segmentFilterFieldType) {
             $segmentFilterFieldType = $this->customFieldRepository->getCustomFieldTypeById($segmentFilterFieldId);
         }
         $dataTable              = $this->fieldTypeProvider->getType($segmentFilterFieldType)->getTableName();

--- a/Helper/QueryFilterFactory.php
+++ b/Helper/QueryFilterFactory.php
@@ -64,7 +64,7 @@ class QueryFilterFactory
     ): UnionQueryContainer {
         $segmentFilterFieldId   = (int) $segmentFilter->getField();
         $segmentFilterFieldType = $segmentFilter->getType();
-        if ($segmentFilterFieldType === 'select' || $segmentFilterFieldType === null || $segmentFilterFieldType === '') {
+        if ('select' === $segmentFilterFieldType || null === $segmentFilterFieldType || '' === $segmentFilterFieldType) {
             $segmentFilterFieldType = $this->customFieldRepository->getCustomFieldTypeById($segmentFilterFieldId);
         }
         $dataTable              = $this->fieldTypeProvider->getType($segmentFilterFieldType)->getTableName();

--- a/Helper/QueryFilterFactory.php
+++ b/Helper/QueryFilterFactory.php
@@ -64,7 +64,8 @@ class QueryFilterFactory
     ): UnionQueryContainer {
         $segmentFilterFieldId   = (int) $segmentFilter->getField();
         $segmentFilterFieldType = $segmentFilter->getType();
-        if (empty($segmentFilterFieldType) || '' === $segmentFilterFieldType) {
+        $segmentFilterFieldType = $segmentFilterFieldType ?: $this->customFieldRepository->getCustomFieldTypeById($segmentFilterFieldId);
+        if ('select' === $segmentFilterFieldType) {
             $segmentFilterFieldType = $this->customFieldRepository->getCustomFieldTypeById($segmentFilterFieldId);
         }
         $dataTable              = $this->fieldTypeProvider->getType($segmentFilterFieldType)->getTableName();

--- a/Helper/QueryFilterFactory.php
+++ b/Helper/QueryFilterFactory.php
@@ -64,11 +64,12 @@ class QueryFilterFactory
     ): UnionQueryContainer {
         $segmentFilterFieldId   = (int) $segmentFilter->getField();
         $segmentFilterFieldType = $segmentFilter->getType();
-        $segmentFilterFieldType = $segmentFilterFieldType ?: $this->customFieldRepository->getCustomFieldTypeById($segmentFilterFieldId);
+        if ($segmentFilterFieldType === 'select' || $segmentFilterFieldType === null || $segmentFilterFieldType === '') {
+            $segmentFilterFieldType = $this->customFieldRepository->getCustomFieldTypeById($segmentFilterFieldId);
+        }
         $dataTable              = $this->fieldTypeProvider->getType($segmentFilterFieldType)->getTableName();
 
         $this->unionQueryContainer = new UnionQueryContainer();
-
         $this->create1LevelQuery($alias, $segmentFilterFieldId, $dataTable);
 
         $currentLevel = 2;

--- a/Helper/QueryFilterHelper.php
+++ b/Helper/QueryFilterHelper.php
@@ -149,6 +149,7 @@ class QueryFilterHelper
 
         switch ($operator) {
             case 'notIn':
+                $segmentQueryBuilder->andWhere($expression);
                 break;
             default:
                 $segmentQueryBuilder->andWhere($expression);

--- a/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
+++ b/Segment/Query/Filter/CustomFieldFilterQueryBuilder.php
@@ -60,11 +60,11 @@ class CustomFieldFilterQueryBuilder extends BaseFilterQueryBuilder
             case '!multiselect':
             case '!between':
             case 'notBetween':
+            case 'notIn': // ← add this line
                 $queryBuilder->addLogic(
                     $queryBuilder->expr()->notExists($unionQueryContainer->getSQL()),
                     $filter->getGlue()
                 );
-
                 break;
             default:
                 $queryBuilder->addLogic(

--- a/Tests/Functional/DataFixtures/ORM/Data/custom_fields.yml
+++ b/Tests/Functional/DataFixtures/ORM/Data/custom_fields.yml
@@ -69,3 +69,11 @@ MauticPlugin\CustomObjectsBundle\Entity\CustomField:
     label: '<word()> Country'
     alias: 'country_11'
     type: 'country'
+  features_field:
+    custom_object: '@custom_object1'   # or @custom_object_car if you defined it
+    is_published: true
+    date_added: '<date_create()>'
+    label: 'Features'
+    alias: 'features'
+    type: 'multiselect'
+

--- a/Tests/Functional/DataFixtures/ORM/Data/custom_objects.yml
+++ b/Tests/Functional/DataFixtures/ORM/Data/custom_objects.yml
@@ -20,3 +20,4 @@ MauticPlugin\CustomObjectsBundle\Entity\CustomObject:
     name_plural: '<sentence(2)>'
     description: '<sentence(2)>'
     alias: 'custom_object_3'
+

--- a/Tests/Functional/DataFixtures/ORM/Data/custom_values_option.yml
+++ b/Tests/Functional/DataFixtures/ORM/Data/custom_values_option.yml
@@ -1,0 +1,15 @@
+MauticPlugin\CustomObjectsBundle\Entity\CustomFieldValueOption:
+  fvo1:  { __construct: ['@features_field', '@custom_item1', 'power_stearing'] }
+  fvo2:  { __construct: ['@features_field', '@custom_item1', '4_star_safety'] }
+
+  fvo3:  { __construct: ['@features_field', '@custom_item2', 'power_stearing'] }
+  fvo4:  { __construct: ['@features_field', '@custom_item2', '5_star_safety'] }
+
+  fvo5:  { __construct: ['@features_field', '@custom_item3', '4_star_safety'] }
+  fvo6:  { __construct: ['@features_field', '@custom_item3', 'power_window'] }
+
+  fvo7:  { __construct: ['@features_field', '@custom_item4', 'electric'] }
+  fvo8:  { __construct: ['@features_field', '@custom_item4', 'power_stearing'] }
+
+  fvo9:  { __construct: ['@features_field', '@custom_item5', 'power_stearing'] }
+  fvo10: { __construct: ['@features_field', '@custom_item5', '4_star_safety'] }

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -170,6 +170,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
     {
         $qb = new QueryBuilder($this->connection);
         $qb->select('l.*')->from('leads', 'l');
+
         return $qb;
     }
 }

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -14,7 +14,6 @@ use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterFactory;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
 use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
 use MauticPlugin\CustomObjectsBundle\Repository\CustomFieldRepository;
-use MauticPlugin\CustomObjectsBundle\Repository\DbalQueryTrait;
 use MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\CustomFieldFilterQueryBuilder;
 use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\FixtureObjectsTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -22,7 +21,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
 {
     use FixtureObjectsTrait;
-    use DbalQueryTrait;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -69,12 +69,11 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
 
         // INCLUDE (IN)
         $includeFilter = $this->createMultiselectFilterMock(
-            fieldId: $cfId,
-            values: ['power_stearing', '4_star_safety'],
-            operator: 'in',        // lowercase
-            type: 'multiselect'
+            $cfId,
+            ['power_stearing', '4_star_safety'],
+            'in',
+            'multiselect'
         );
-
         $qb = $this->baseLeadsQB();
         $qbService->applyQuery($qb, $includeFilter);
         $this->assertGreaterThanOrEqual(
@@ -85,10 +84,10 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
 
         // EXCLUDE (NOT IN)
         $excludeFilter = $this->createMultiselectFilterMock(
-            fieldId: $cfId,
-            values: ['power_stearing', '4_star_safety'],
-            operator: 'notIn',     // exact camelCase
-            type: 'multiselect'
+            $cfId,
+            ['power_stearing', '4_star_safety'],
+            'notIn',
+            'multiselect'
         );
         $qb2 = $this->baseLeadsQB();
         $qbService->applyQuery($qb2, $excludeFilter);

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -29,6 +29,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
     {
         $this->configParams['custom_object_merge_filter'] = false;
         parent::setUp();
+        defined('MAUTIC_TABLE_PREFIX') || define('MAUTIC_TABLE_PREFIX', '');
     }
 
     public function testIncludeAndExcludeOnMultiselectField(): void

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -17,7 +17,6 @@ use MauticPlugin\CustomObjectsBundle\Repository\CustomFieldRepository;
 use MauticPlugin\CustomObjectsBundle\Repository\DbalQueryTrait;
 use MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\CustomFieldFilterQueryBuilder;
 use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\FixtureObjectsTrait;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
@@ -74,13 +73,8 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
             'in',
             'multiselect'
         );
-        $qb = $this->baseLeadsQB();
-        $qbService->applyQuery($qb, $includeFilter);
-        $this->assertGreaterThanOrEqual(
-            1,
-            $this->executeSelect($qb)->rowCount(),
-            'IN should match at least one contact'
-        );
+        $includeIds = $this->fetchLeadIdsForFilter($qbService, $includeFilter);
+        $this->assertNotEmpty($includeIds, 'IN should match at least one contact');
 
         // EXCLUDE (NOT IN)
         $excludeFilter = $this->createMultiselectFilterMock(
@@ -89,13 +83,8 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
             'notIn',
             'multiselect'
         );
-        $qb2 = $this->baseLeadsQB();
-        $qbService->applyQuery($qb2, $excludeFilter);
-        $this->assertGreaterThanOrEqual(
-            0,
-            $this->executeSelect($qb2)->rowCount(),
-            'NOT IN should return contacts without those values'
-        );
+        $excludeIds = $this->fetchLeadIdsForFilter($qbService, $excludeFilter);
+        $this->assertIsArray($excludeIds);
     }
 
     private function findMultiselectFieldIdOrSkip(): int
@@ -120,7 +109,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
         // DBAL 2/3-safe fallback: pick any field that has option rows
         $qb2 = $this->connection->createQueryBuilder()
             ->select('v.custom_field_id')
-            ->from(MAUTIC_TABLE_PREFIX.'custom_field_value_option', 'v')
+            ->from($this->prefixTable('custom_field_value_option'), 'v')
             ->setMaxResults(1);
 
         $stmt = method_exists($qb2, 'executeQuery') ? $qb2->executeQuery() : $qb2->execute();
@@ -139,11 +128,11 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
      * @return ContactSegmentFilter&\PHPUnit\Framework\MockObject\MockObject
      */
     private function createMultiselectFilterMock(
-    int $fieldId,
-    array $values,
-    string $operator = 'in',
-    string $type = 'multiselect'
-    ): MockObject {
+        int $fieldId,
+        array $values,
+        string $operator = 'in',
+        string $type = 'multiselect'
+    ): ContactSegmentFilter {
         // Normalize operator to what prod code expects
         $raw  = (string) $operator;
         $low  = strtolower($raw);
@@ -155,10 +144,11 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
             $normalized = $raw; // pass through others (eq, neq, etc.)
         }
 
+        /** @var ContactSegmentFilter&\PHPUnit\Framework\MockObject\MockObject $filter */
         $filter                            = $this->getMockBuilder(ContactSegmentFilter::class)->disableOriginalConstructor()->getMock();
         $filter->contactSegmentFilterCrate = $this->createMock(ContactSegmentFilterCrate::class);
-        $filter->method('getType')->willReturn($type);          // keep 'multiselect' here for option table mapping
-        $filter->method('getOperator')->willReturn($normalized); // <-- normalized op
+        $filter->method('getType')->willReturn($type);           // keep 'multiselect' here for option table mapping
+        $filter->method('getOperator')->willReturn($normalized); // normalized op
         $filter->method('getField')->willReturn((string) $fieldId);
         $filter->method('getParameterValue')->willReturn($values);
         $filter->method('getParameterHolder')->willReturn(':needle');
@@ -166,11 +156,48 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
         return $filter;
     }
 
-    private function baseLeadsQB(): QueryBuilder
+    /**
+     * Prefixes a table name using the current DB configuration or the MAUTIC_TABLE_PREFIX constant.
+     */
+    private function prefixTable(string $table): string
     {
-        $qb = new QueryBuilder($this->connection);
-        $qb->select('l.*')->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
+        $prefix = '';
+        // Don’t use isset() — PHPStan considers static::$container non-nullable.
+        try {
+            // In Mautic test envs this parameter exists.
+            $prefix = (string) self::$container->getParameter('mautic.db_table_prefix');
+        } catch (\Throwable $e) {
+            if (defined('MAUTIC_TABLE_PREFIX')) {
+                $prefix = (string) MAUTIC_TABLE_PREFIX;
+            }
+        }
 
-        return $qb;
+        return $prefix.$table;
+    }
+
+    /**
+     * Return distinct lead IDs matched by a filter.
+     *
+     * @return list<int>
+     */
+    private function fetchLeadIdsForFilter(
+        CustomFieldFilterQueryBuilder $svc,
+        ContactSegmentFilter $filter
+    ): array {
+        $qb = new QueryBuilder($this->connection);
+        $qb->select('DISTINCT l.id')->from($this->prefixTable('leads'), 'l');
+
+        $svc->applyQuery($qb, $filter);
+
+        $stmt = method_exists($qb, 'executeQuery') ? $qb->executeQuery() : $qb->execute();
+        /** @var list<int|string> $col */
+        $col = method_exists($stmt, 'fetchFirstColumn')
+            ? $stmt->fetchFirstColumn()
+            : array_column($stmt->fetchAll(\PDO::FETCH_NUM), 0);
+
+        $ids = array_values(array_unique(array_map('intval', $col)));
+        sort($ids);
+
+        return $ids;
     }
 }

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\Segment\Query\Filter;
+
+use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\FixtureObjectsTrait;
+use MauticPlugin\CustomObjectsBundle\Repository\DbalQueryTrait;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Segment\ContactSegmentFilter;
+use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\RandomParameterName;
+use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterFactory;
+use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
+use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
+use MauticPlugin\CustomObjectsBundle\Repository\CustomFieldRepository;
+use MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\CustomFieldFilterQueryBuilder;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
+{
+    use FixtureObjectsTrait;
+    use DbalQueryTrait;
+
+    protected function setUp(): void
+    {
+        $this->configParams['custom_object_merge_filter'] = false;
+        parent::setUp();
+    }
+
+    public function testIncludeAndExcludeOnMultiselectField(): void
+    {
+        $fixturesDir = $this->getFixturesDirectory();
+        $objects     = $this->loadFixtureFiles([
+            $fixturesDir.'/leads.yml',
+            $fixturesDir.'/custom_objects.yml',
+            $fixturesDir.'/custom_fields.yml',
+            $fixturesDir.'/custom_items.yml',
+            $fixturesDir.'/custom_xref.yml',
+            $fixturesDir.'/custom_values.yml',
+            $fixturesDir.'/custom_values_option.yml',
+        ]);
+        $this->setFixtureObjects($objects);
+
+        $cfId = $this->findMultiselectFieldIdOrSkip();
+
+        /** @var CustomFieldTypeProvider $typeProvider */
+        $typeProvider = self::$container->get('custom_field.type.provider');
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher   = self::$container->get('event_dispatcher');
+        /** @var CustomFieldRepository $cfRepoSvc */
+        $cfRepoSvc    = self::$container->get('custom_field.repository');
+
+        $helper = new QueryFilterHelper(
+            $this->em,
+            new QueryFilterFactory(
+                $this->em,
+                $typeProvider,
+                $cfRepoSvc,
+                new QueryFilterFactory\Calculator(),
+                1
+            ),
+            new RandomParameterName()
+        );
+        $qbService = new CustomFieldFilterQueryBuilder(new RandomParameterName(), $dispatcher, $helper);
+
+        // INCLUDE (IN)
+       $includeFilter = $this->createMultiselectFilterMock(
+            fieldId: $cfId,
+            values: ['power_stearing', '4_star_safety'],
+            operator: 'in',        // lowercase
+            type: 'multiselect'
+        );
+
+        $qb = $this->baseLeadsQB();
+        $qbService->applyQuery($qb, $includeFilter);
+        $this->assertGreaterThanOrEqual(
+            1,
+            $this->executeSelect($qb)->rowCount(),
+            'IN should match at least one contact'
+        );
+
+        // EXCLUDE (NOT IN)
+        $excludeFilter = $this->createMultiselectFilterMock(
+            fieldId: $cfId,
+            values: ['power_stearing', '4_star_safety'],
+            operator: 'notIn',     // exact camelCase
+            type: 'multiselect'
+        );
+        $qb2 = $this->baseLeadsQB();
+        $qbService->applyQuery($qb2, $excludeFilter);
+        $this->assertGreaterThanOrEqual(
+            0,
+            $this->executeSelect($qb2)->rowCount(),
+            'NOT IN should return contacts without those values'
+        );
+    }
+
+    private function findMultiselectFieldIdOrSkip(): int
+    {
+        $repo    = $this->em->getRepository(CustomField::class);
+        $byLabel = $repo->findOneBy(['label' => 'Features']);
+        if ($byLabel instanceof CustomField) {
+            return (int) $byLabel->getId();
+        }
+
+        $qb = $repo->createQueryBuilder('f');
+        $field = $qb
+            ->where($qb->expr()->in('f.type', ':types'))
+            ->setParameter('types', ['option', 'multiselect'])
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+        if ($field instanceof CustomField) {
+            return (int) $field->getId();
+        }
+
+        // DBAL 2/3-safe fallback: pick any field that has option rows
+        $qb2 = $this->connection->createQueryBuilder()
+            ->select('v.custom_field_id')
+            ->from(MAUTIC_TABLE_PREFIX.'custom_field_value_option', 'v')
+            ->setMaxResults(1);
+
+        $stmt = method_exists($qb2, 'executeQuery') ? $qb2->executeQuery() : $qb2->execute();
+        $cfId = (int) (method_exists($stmt, 'fetchOne') ? $stmt->fetchOne() : $stmt->fetchColumn());
+
+        if ($cfId > 0) {
+            return $cfId;
+        }
+
+        $this->markTestSkipped('No multiselect/option field found in fixtures.');
+    }
+
+    private function createMultiselectFilterMock(
+    int $fieldId,
+    array $values,
+    string $operator = 'in',
+    string $type = 'multiselect'
+    ): MockObject {
+        // Normalize operator to what prod code expects
+        $raw  = (string) $operator;
+        $low  = strtolower($raw);
+        if ($low === 'in' || $low === 'multiselect') {
+            $normalized = 'in';
+        } elseif ($low === 'notin' || $raw === '!multiselect') {
+            $normalized = 'notIn';
+        } else {
+            $normalized = $raw; // pass through others (eq, neq, etc.)
+        }
+
+        $filter = $this->getMockBuilder(ContactSegmentFilter::class)->disableOriginalConstructor()->getMock();
+        $filter->contactSegmentFilterCrate = $this->createMock(ContactSegmentFilterCrate::class);
+        $filter->method('getType')->willReturn($type);          // keep 'multiselect' here for option table mapping
+        $filter->method('getOperator')->willReturn($normalized); // <-- normalized op
+        $filter->method('getField')->willReturn((string) $fieldId);
+        $filter->method('getParameterValue')->willReturn($values);
+        $filter->method('getParameterHolder')->willReturn(':needle');
+
+        return $filter;
+    }
+
+
+    private function baseLeadsQB(): QueryBuilder
+    {
+        $qb = new QueryBuilder($this->connection);
+        $qb->select('l.*')->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
+        return $qb;
+    }
+}

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -29,7 +29,6 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
     {
         $this->configParams['custom_object_merge_filter'] = false;
         parent::setUp();
-        defined('MAUTIC_TABLE_PREFIX') || define('MAUTIC_TABLE_PREFIX', '');
     }
 
     public function testIncludeAndExcludeOnMultiselectField(): void
@@ -121,7 +120,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
         // DBAL 2/3-safe fallback: pick any field that has option rows
         $qb2 = $this->connection->createQueryBuilder()
             ->select('v.custom_field_id')
-            ->from(MAUTIC_TABLE_PREFIX.'custom_field_value_option', 'v')
+            ->from('custom_field_value_option', 'v')
             ->setMaxResults(1);
 
         $stmt = method_exists($qb2, 'executeQuery') ? $qb2->executeQuery() : $qb2->execute();
@@ -170,8 +169,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
     private function baseLeadsQB(): QueryBuilder
     {
         $qb = new QueryBuilder($this->connection);
-        $qb->select('l.*')->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
-
+        $qb->select('l.*')->from('leads', 'l');
         return $qb;
     }
 }

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Tests\Functional\Segment\Query\Filter;
 
-use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\FixtureObjectsTrait;
-use MauticPlugin\CustomObjectsBundle\Repository\DbalQueryTrait;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use Mautic\LeadBundle\Segment\RandomParameterName;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterFactory;
 use MauticPlugin\CustomObjectsBundle\Helper\QueryFilterHelper;
 use MauticPlugin\CustomObjectsBundle\Provider\CustomFieldTypeProvider;
 use MauticPlugin\CustomObjectsBundle\Repository\CustomFieldRepository;
+use MauticPlugin\CustomObjectsBundle\Repository\DbalQueryTrait;
 use MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\CustomFieldFilterQueryBuilder;
-use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
+use MauticPlugin\CustomObjectsBundle\Tests\Functional\DataFixtures\Traits\FixtureObjectsTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -68,7 +68,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
         $qbService = new CustomFieldFilterQueryBuilder(new RandomParameterName(), $dispatcher, $helper);
 
         // INCLUDE (IN)
-       $includeFilter = $this->createMultiselectFilterMock(
+        $includeFilter = $this->createMultiselectFilterMock(
             fieldId: $cfId,
             values: ['power_stearing', '4_star_safety'],
             operator: 'in',        // lowercase
@@ -107,7 +107,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
             return (int) $byLabel->getId();
         }
 
-        $qb = $repo->createQueryBuilder('f');
+        $qb    = $repo->createQueryBuilder('f');
         $field = $qb
             ->where($qb->expr()->in('f.type', ':types'))
             ->setParameter('types', ['option', 'multiselect'])
@@ -134,6 +134,11 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
         $this->markTestSkipped('No multiselect/option field found in fixtures.');
     }
 
+    /**
+     * @param list<string> $values
+     *
+     * @return ContactSegmentFilter&\PHPUnit\Framework\MockObject\MockObject
+     */
     private function createMultiselectFilterMock(
     int $fieldId,
     array $values,
@@ -143,15 +148,15 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
         // Normalize operator to what prod code expects
         $raw  = (string) $operator;
         $low  = strtolower($raw);
-        if ($low === 'in' || $low === 'multiselect') {
+        if ('in' === $low || 'multiselect' === $low) {
             $normalized = 'in';
-        } elseif ($low === 'notin' || $raw === '!multiselect') {
+        } elseif ('notin' === $low || '!multiselect' === $raw) {
             $normalized = 'notIn';
         } else {
             $normalized = $raw; // pass through others (eq, neq, etc.)
         }
 
-        $filter = $this->getMockBuilder(ContactSegmentFilter::class)->disableOriginalConstructor()->getMock();
+        $filter                            = $this->getMockBuilder(ContactSegmentFilter::class)->disableOriginalConstructor()->getMock();
         $filter->contactSegmentFilterCrate = $this->createMock(ContactSegmentFilterCrate::class);
         $filter->method('getType')->willReturn($type);          // keep 'multiselect' here for option table mapping
         $filter->method('getOperator')->willReturn($normalized); // <-- normalized op
@@ -162,11 +167,11 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
         return $filter;
     }
 
-
     private function baseLeadsQB(): QueryBuilder
     {
         $qb = new QueryBuilder($this->connection);
         $qb->select('l.*')->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
+
         return $qb;
     }
 }

--- a/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
+++ b/Tests/Functional/Segment/Query/Filter/CustomFieldFilterQueryBuilderMultiselectTest.php
@@ -120,7 +120,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
         // DBAL 2/3-safe fallback: pick any field that has option rows
         $qb2 = $this->connection->createQueryBuilder()
             ->select('v.custom_field_id')
-            ->from('custom_field_value_option', 'v')
+            ->from(MAUTIC_TABLE_PREFIX.'custom_field_value_option', 'v')
             ->setMaxResults(1);
 
         $stmt = method_exists($qb2, 'executeQuery') ? $qb2->executeQuery() : $qb2->execute();
@@ -169,7 +169,7 @@ class CustomFieldFilterQueryBuilderMultiselectTest extends MauticMysqlTestCase
     private function baseLeadsQB(): QueryBuilder
     {
         $qb = new QueryBuilder($this->connection);
-        $qb->select('l.*')->from('leads', 'l');
+        $qb->select('l.*')->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
         return $qb;
     }


### PR DESCRIPTION
PR : https://acquia.atlassian.net/browse/MAUT-11554

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ YES]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://acquia.atlassian.net/browse/MAUT-11554


#### Description:
Operators not working for custom object segment filters.

not empty, including, excluding operators are not working for Multiselect field in custom object for segments

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->