### PR TITLE
#12891: Fixed issue for Cuctom object for country filter

### DIFF
--- a/EventListener/DynamicContentSubscriber.php
+++ b/EventListener/DynamicContentSubscriber.php
@@ -74,40 +74,41 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         return false;
     }
 
+    /**
+     * @param array<int, array<string, mixed>> $filters
+     *
+     * @return array<int, array<string, mixed>>
+     */
     private function normalizeCustomObjectFilters(array $filters): array
-{
-    foreach ($filters as &$filter) {
+    {
+        foreach ($filters as &$filter) {
+            if (
+                !isset($filter['properties']['options']) ||
+                !is_array($filter['properties']['options'])
+            ) {
+                continue;
+            }
 
-        // Only normalize filters that have options (custom objects)
-        if (
-            !isset($filter['properties']['options']) ||
-            !is_array($filter['properties']['options'])
-        ) {
-            continue;
+            $label = $filter['filter_value'] ?? null;
+            if (!$label) {
+                continue;
+            }
+
+            $options = $filter['properties']['options'];
+
+            // Case A: Standard format (label => value)
+            if (isset($options[$label])) {
+                $filter['filter_value'] = $options[$label];
+                continue;
+            }
+
+            // Case B: Reverse format (value => label)
+            $reversed = array_flip($options);
+            if (isset($reversed[$label])) {
+                $filter['filter_value'] = $reversed[$label];
+            }
         }
 
-        $label = $filter['filter_value'] ?? null;
-        if (!$label) {
-            continue;
-        }
-
-        $options = $filter['properties']['options'];
-
-        // Case A: Standard format (label => value)
-        if (isset($options[$label])) {
-            $filter['filter_value'] = $options[$label];
-            continue;
-        }
-
-        // Case B: Reverse format (value => label)
-        $reversed = array_flip($options);
-        if (isset($reversed[$label])) {
-            $filter['filter_value'] = $reversed[$label];
-            continue;
-        }
+        return $filters;
     }
-
-    return $filters;
-}
-
 }

--- a/EventListener/DynamicContentSubscriber.php
+++ b/EventListener/DynamicContentSubscriber.php
@@ -40,9 +40,11 @@ class DynamicContentSubscriber implements EventSubscriberInterface
 
     public function evaluateFilters(ContactFiltersEvaluateEvent $event): void
     {
+        // 2. Normalize only Custom Object filters
+        $filters = $this->normalizeCustomObjectFilters($event->getFilters());
         if ($event->isEvaluated()
             || !$this->configProvider->pluginIsEnabled()
-            || !$this->hasCustomObjectFilters($event->getFilters())
+            || !$this->hasCustomObjectFilters($filters)
         ) {
             return;
         }
@@ -50,7 +52,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         $event->setIsEvaluated(true);
         $event->stopPropagation();
         $event->setIsMatched($this->contactFilterMatcher->match(
-            $event->getFilters(),
+            $filters,
             $event->getContact()->getProfileFields()
         ));
     }
@@ -71,4 +73,41 @@ class DynamicContentSubscriber implements EventSubscriberInterface
 
         return false;
     }
+
+    private function normalizeCustomObjectFilters(array $filters): array
+{
+    foreach ($filters as &$filter) {
+
+        // Only normalize filters that have options (custom objects)
+        if (
+            !isset($filter['properties']['options']) ||
+            !is_array($filter['properties']['options'])
+        ) {
+            continue;
+        }
+
+        $label = $filter['filter_value'] ?? null;
+        if (!$label) {
+            continue;
+        }
+
+        $options = $filter['properties']['options'];
+
+        // Case A: Standard format (label => value)
+        if (isset($options[$label])) {
+            $filter['filter_value'] = $options[$label];
+            continue;
+        }
+
+        // Case B: Reverse format (value => label)
+        $reversed = array_flip($options);
+        if (isset($reversed[$label])) {
+            $filter['filter_value'] = $reversed[$label];
+            continue;
+        }
+    }
+
+    return $filters;
+}
+
 }

--- a/Helper/QueryFilterFactory.php
+++ b/Helper/QueryFilterFactory.php
@@ -66,7 +66,6 @@ class QueryFilterFactory
         $segmentFilterFieldType = $segmentFilter->getType();
         $segmentFilterFieldType = $segmentFilterFieldType ?: $this->customFieldRepository->getCustomFieldTypeById($segmentFilterFieldId);
         $dataTable              = $this->fieldTypeProvider->getType($segmentFilterFieldType)->getTableName();
-
         $this->unionQueryContainer = new UnionQueryContainer();
 
         $this->create1LevelQuery($alias, $segmentFilterFieldId, $dataTable);

--- a/Helper/QueryFilterFactory.php
+++ b/Helper/QueryFilterFactory.php
@@ -66,6 +66,7 @@ class QueryFilterFactory
         $segmentFilterFieldType = $segmentFilter->getType();
         $segmentFilterFieldType = $segmentFilterFieldType ?: $this->customFieldRepository->getCustomFieldTypeById($segmentFilterFieldId);
         $dataTable              = $this->fieldTypeProvider->getType($segmentFilterFieldType)->getTableName();
+
         $this->unionQueryContainer = new UnionQueryContainer();
 
         $this->create1LevelQuery($alias, $segmentFilterFieldId, $dataTable);

--- a/Tests/Functional/Helper/DynamicContentSubscriberTest.php
+++ b/Tests/Functional/Helper/DynamicContentSubscriberTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\CustomObjectsBundle\Tests\EventListener;
+
+use Mautic\DynamicContentBundle\Event\ContactFiltersEvaluateEvent;
+use Mautic\LeadBundle\Entity\Lead;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
+use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
+use MauticPlugin\CustomObjectsBundle\EventListener\DynamicContentSubscriber;
+use MauticPlugin\CustomObjectsBundle\Helper\ContactFilterMatcher;
+use MauticPlugin\CustomObjectsBundle\Provider\ConfigProvider;
+use MauticPlugin\CustomObjectsBundle\Repository\CustomFieldRepository;
+use MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\QueryFilterFactory;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+
+class DynamicContentSubscriberTest extends MauticMysqlTestCase
+{
+    private CustomObject $object;
+    private CustomField $field;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // --- Create Custom Object ---
+        $this->object = new CustomObject();
+        $this->object->setNameSingular("TestObject");
+        $this->object->setNamePlural("TestObjects");
+        $this->object->setAlias("testobject");
+        $this->object->setIsPublished(true);
+        $this->em->persist($this->object);
+
+        // --- Create Custom Field ---
+        $this->field = new CustomField();
+        $this->field->setLabel("Country");
+        $this->field->setAlias("country");
+        $this->field->setCustomObject($this->object);
+        $this->field->setType("select");         // important
+        $this->field->setIsPublished(true);
+
+        // Create Doctrine Collection of option entities
+        $options = new \Doctrine\Common\Collections\ArrayCollection();
+
+        // Albania => AL
+        $opt1 = new \MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption();
+        $opt1->setLabel("Albania");
+        $opt1->setValue("AL");
+        $opt1->setCustomField($this->field);
+        $options->add($opt1);
+
+        // France => FR
+        $opt2 = new \MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption();
+        $opt2->setLabel("France");
+        $opt2->setValue("FR");
+        $opt2->setCustomField($this->field);
+        $options->add($opt2);
+
+        // Assign options
+        $this->field->setOptions($options);
+
+        // Persist all
+        $this->em->persist($this->field);
+        $this->em->persist($opt1);
+        $this->em->persist($opt2);
+        $this->em->flush();
+    }
+
+    public function testCustomObjectLabelIsConvertedToValue(): void
+    {
+        // --- Build filter using the custom field we created ---
+        $filters = [[
+            'object'       => 'custom_object',
+            'field'        => $this->field->getId(),
+            'filter_type'  => 'text',
+            'filter_value' => 'Albania',
+            'properties'   => [
+                'options' => [
+                    "Albania" => "AL",
+                    "France"  => "FR",
+                ],
+            ],
+        ]];
+
+        // --- Mock dependencies ---
+        $configProvider = $this->createMock(ConfigProvider::class);
+        $configProvider->method('pluginIsEnabled')->willReturn(true);
+
+        $queryFilterFactory = static::getContainer()->get(QueryFilterFactory::class);
+        $matcher            = static::getContainer()->get(ContactFilterMatcher::class);
+
+        $subscriber = new DynamicContentSubscriber(
+            $queryFilterFactory,
+            $configProvider,
+            $matcher
+        );
+
+        // Dummy contact
+        $contact = new Lead();
+
+        // Build event
+        $event = new ContactFiltersEvaluateEvent($filters, $contact);
+
+        // Execute subscriber
+        $subscriber->evaluateFilters($event);
+
+        // --- Expect the filter to be normalized ---
+        // Use reflection to call normalizeCustomObjectFilters() directly
+        $method = new \ReflectionMethod(DynamicContentSubscriber::class, 'normalizeCustomObjectFilters');
+        $method->setAccessible(true);
+
+        $normalized = $method->invoke($subscriber, $filters);
+
+        $this->assertSame(
+            "AL",
+            $normalized[0]['filter_value'],
+            'Label "Albania" was not normalized to "AL"'
+        );
+    }
+}

--- a/Tests/Functional/Helper/DynamicContentSubscriberTest.php
+++ b/Tests/Functional/Helper/DynamicContentSubscriberTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\CustomObjectsBundle\Tests\EventListener;
 
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\DynamicContentBundle\Event\ContactFiltersEvaluateEvent;
 use Mautic\LeadBundle\Entity\Lead;
 use MauticPlugin\CustomObjectsBundle\Entity\CustomField;
@@ -11,9 +12,7 @@ use MauticPlugin\CustomObjectsBundle\Entity\CustomObject;
 use MauticPlugin\CustomObjectsBundle\EventListener\DynamicContentSubscriber;
 use MauticPlugin\CustomObjectsBundle\Helper\ContactFilterMatcher;
 use MauticPlugin\CustomObjectsBundle\Provider\ConfigProvider;
-use MauticPlugin\CustomObjectsBundle\Repository\CustomFieldRepository;
 use MauticPlugin\CustomObjectsBundle\Segment\Query\Filter\QueryFilterFactory;
-use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 
 class DynamicContentSubscriberTest extends MauticMysqlTestCase
 {
@@ -26,18 +25,18 @@ class DynamicContentSubscriberTest extends MauticMysqlTestCase
 
         // --- Create Custom Object ---
         $this->object = new CustomObject();
-        $this->object->setNameSingular("TestObject");
-        $this->object->setNamePlural("TestObjects");
-        $this->object->setAlias("testobject");
+        $this->object->setNameSingular('TestObject');
+        $this->object->setNamePlural('TestObjects');
+        $this->object->setAlias('testobject');
         $this->object->setIsPublished(true);
         $this->em->persist($this->object);
 
         // --- Create Custom Field ---
         $this->field = new CustomField();
-        $this->field->setLabel("Country");
-        $this->field->setAlias("country");
+        $this->field->setLabel('Country');
+        $this->field->setAlias('country');
         $this->field->setCustomObject($this->object);
-        $this->field->setType("select");         // important
+        $this->field->setType('select');         // important
         $this->field->setIsPublished(true);
 
         // Create Doctrine Collection of option entities
@@ -45,15 +44,15 @@ class DynamicContentSubscriberTest extends MauticMysqlTestCase
 
         // Albania => AL
         $opt1 = new \MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption();
-        $opt1->setLabel("Albania");
-        $opt1->setValue("AL");
+        $opt1->setLabel('Albania');
+        $opt1->setValue('AL');
         $opt1->setCustomField($this->field);
         $options->add($opt1);
 
         // France => FR
         $opt2 = new \MauticPlugin\CustomObjectsBundle\Entity\CustomFieldOption();
-        $opt2->setLabel("France");
-        $opt2->setValue("FR");
+        $opt2->setLabel('France');
+        $opt2->setValue('FR');
         $opt2->setCustomField($this->field);
         $options->add($opt2);
 
@@ -77,8 +76,8 @@ class DynamicContentSubscriberTest extends MauticMysqlTestCase
             'filter_value' => 'Albania',
             'properties'   => [
                 'options' => [
-                    "Albania" => "AL",
-                    "France"  => "FR",
+                    'Albania' => 'AL',
+                    'France'  => 'FR',
                 ],
             ],
         ]];
@@ -113,7 +112,7 @@ class DynamicContentSubscriberTest extends MauticMysqlTestCase
         $normalized = $method->invoke($subscriber, $filters);
 
         $this->assertSame(
-            "AL",
+            'AL',
             $normalized[0]['filter_value'],
             'Label "Albania" was not normalized to "AL"'
         );


### PR DESCRIPTION
Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ YES]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://acquia.atlassian.net/browse/MAUT-12891



#### Description:
- Custom Object Country list filter is not working for Dynamic Web Content


#### Steps to Reproduce:
- Create a custom object with country list field
- Create custom items with different countries and link it with contacts
- Create DWC with custom object country list filter
- Use the DWC in email/landing page
- Verify DWC shows default content for all values irrespective of filter, which is a issue

#### Steps to test this PR:
 - Create a custom object with country list field
 - Create custom items with different countries and link it with contacts
 - Create DWC with custom object country list filter lets say equal to "Albania" and add some Slot
 - Use the DWC in email/landing page and Under builder select DWC and add some default messages for Same Slot selected in DWC above.
 - Use landing page preview page and input username and see for users having attached city Equal to 'Albania' are show with DWC message content and not Default content
 - Users with Not attached to items having 'Albania' should show Default content message.

![Uploading Screenshot 2025-11-18 at 7.14.18 PM.png…]()
